### PR TITLE
RF: change default delocation to look in all files

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -248,7 +248,7 @@ def filter_system_libs(libname):
 
 
 def delocate_path(tree_path, lib_path,
-                  lib_filt_func = _dylibs_only,
+                  lib_filt_func = None,
                   copy_filt_func = filter_system_libs):
     """ Copy required libraries for files in `tree_path` into `lib_path`
 
@@ -258,11 +258,11 @@ def delocate_path(tree_path, lib_path,
         Root path of tree to search for required libraries
     lib_path : str
         Directory into which we copy required libraries
-    lib_filt_func : None or callable, optional
+    lib_filt_func : None or str or callable, optional
         If None, inspect all files for dependencies on dynamic libraries. If
         callable, accepts filename as argument, returns True if we should
-        inspect the file, False otherwise. Default is callable rejecting all
-        but files ending in ``.so`` or ``.dylib``.
+        inspect the file, False otherwise. If str == "dylibs-only" then inspect
+        only files with known dynamic library extensions (``.dylib``, ``.so``).
     copy_filt_func : None or callable, optional
         If callable, called on each library name detected as a dependency; copy
         where ``copy_filt_func(libname)`` is True, don't copy otherwise.
@@ -281,6 +281,8 @@ def delocate_path(tree_path, lib_path,
         is the ``install_name`` of ``copied_lib_path`` in the depending
         library.
     """
+    if lib_filt_func == "dylibs-only":
+        lib_filt_func = _dylibs_only
     if not exists(lib_path):
         os.makedirs(lib_path)
     lib_dict = tree_libs(tree_path, lib_filt_func)
@@ -305,7 +307,7 @@ def _merge_lib_dict(d1, d2):
 def delocate_wheel(in_wheel,
                    out_wheel = None,
                    lib_sdir = '.dylibs',
-                   lib_filt_func = _dylibs_only,
+                   lib_filt_func = None,
                    copy_filt_func = filter_system_libs,
                    require_archs = None,
                    check_verbose = False,
@@ -327,11 +329,11 @@ def delocate_wheel(in_wheel,
     lib_sdir : str, optional
         Subdirectory name in wheel package directory (or directories) to store
         needed libraries.
-    lib_filt_func : None or callable, optional
+    lib_filt_func : None or str or callable, optional
         If None, inspect all files for dependencies on dynamic libraries. If
         callable, accepts filename as argument, returns True if we should
-        inspect the file, False otherwise. Default is callable rejecting all
-        but files ending in ``.so`` or ``.dylib``.
+        inspect the file, False otherwise. If str == "dylibs-only" then inspect
+        only files with known dynamic library extensions (``.dylib``, ``.so``).
     copy_filt_func : None or callable, optional
         If callable, called on each library name detected as a dependency; copy
         where ``copy_filt_func(libname)`` is True, don't copy otherwise.
@@ -360,6 +362,8 @@ def delocate_wheel(in_wheel,
         is the ``install_name`` of ``copied_lib_path`` in the depending
         library. The filenames in the keys are relative to the wheel root path.
     """
+    if lib_filt_func == "dylibs-only":
+        lib_filt_func = _dylibs_only
     in_wheel = abspath(in_wheel)
     if out_wheel is None:
         out_wheel = in_wheel

--- a/scripts/delocate-path
+++ b/scripts/delocate-path
@@ -14,10 +14,14 @@ def main():
     parser = OptionParser(
         usage="%s PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)
-    parser.add_option(
+    parser.add_options([
         Option("-L", "--lib-path",
                action="store", type='string',
-               help="Output path to copy library dependencies"))
+               help="Output subdirectory path to copy library dependencies"),
+        Option("-d", "--dylibs-only",
+               action="store_true",
+               help="Only analyze files with known dynamic library "
+               "extensions")])
     (opts, paths) = parser.parse_args()
     if len(paths) < 1:
         parser.print_help()
@@ -25,13 +29,14 @@ def main():
 
     if opts.lib_path is None:
         opts.lib_path = '.dylibs'
+    lib_filt_func = 'dylibs-only' if opts.dylibs_only else None
     multi = len(paths) > 1
     for path in paths:
         if multi:
             print(path)
         # evaluate paths relative to the path we are working on
         lib_path = os.path.join(path, opts.lib_path)
-        delocate_path(path, lib_path)
+        delocate_path(path, lib_path, lib_filt_func)
 
 
 if __name__ == '__main__':

--- a/scripts/delocate-wheel
+++ b/scripts/delocate-wheel
@@ -18,28 +18,28 @@ def main():
     parser = OptionParser(
         usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)
-    parser.add_option(
+    parser.add_options([
         Option("-L", "--lib-sdir",
                action="store", type='string', default='.dylibs',
-               help="Subdirectory in packages to store copied libraries"))
-    parser.add_option(
+               help="Subdirectory in packages to store copied libraries"),
         Option("-w", "--wheel-dir",
                action="store", type='string',
                help="Directory to store delocated wheels (default is to "
-               "overwrite input)"))
-    parser.add_option(
+               "overwrite input)"),
         Option("-v", "--verbose",
                action="store_true",
-               help="Show more verbose report of progress and failure"))
-    parser.add_option(
+               help="Show more verbose report of progress and failure"),
         Option("-k", "--check-archs",
                action="store_true",
-               help="Check architectures of depended libraries"))
-    parser.add_option(
+               help="Check architectures of depended libraries"),
+        Option("-d", "--dylibs-only",
+               action="store_true",
+               help="Only analyze files with known dynamic library "
+               "extensions"),
         Option("--require-archs",
                action="store", type='string',
                help="Architectures that all wheel libraries should "
-               "have (from 'intel', 'i386', 'x86_64', 'i386,x86_64')"))
+               "have (from 'intel', 'i386', 'x86_64', 'i386,x86_64')")])
     (opts, wheels) = parser.parse_args()
     if len(wheels) < 1:
         parser.print_help()
@@ -57,6 +57,7 @@ def main():
         require_archs = [s.strip() for s in opts.require_archs.split(',')]
     else:
         require_archs = opts.require_archs
+    lib_filt_func = 'dylibs-only' if opts.dylibs_only else None
     for wheel in wheels:
         if multi or opts.verbose:
             print('Fixing: ' + wheel)
@@ -64,7 +65,8 @@ def main():
             out_wheel = pjoin(wheel_dir, basename(wheel))
         else:
             out_wheel = wheel
-        copied = delocate_wheel(wheel, out_wheel, lib_sdir=opts.lib_sdir,
+        copied = delocate_wheel(wheel, out_wheel, lib_filt_func=lib_filt_func,
+                                lib_sdir=opts.lib_sdir,
                                 require_archs=require_archs,
                                 check_verbose=opts.verbose)
         if opts.verbose and len(copied):


### PR DESCRIPTION
Previously delocate_path and delocate_wheel were only looking for dependencies
in files with extensions '.dylib' or '.so'.  Change the default to look in all
files.  Add argument for scripts and functions to choose previous behavior.