### PR TITLE
DOC: link to `auditwheel` from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,9 @@ Provides scripts:
 * ``delocate-wheel`` -- rewrite wheel having copied and relinked library
   dependencies into the wheel tree.
 
+`auditwheel <https://github.com/pypa/auditwheel>`_ is a tool for Linux
+similar to ``delocate``, on which it was based.
+
 .. warning::
 
     Please be careful - this software is alpha quality and has not been much


### PR DESCRIPTION
Addresses #16.

The only way I know of formatting text within a link as code is

```rst
`:code:`auditwheel` <https://github.com/pypa/auditwheel>`_
```

This works locally (with `rst-preview-pandoc@0.1.12` in `atom`), but doesn't render properly on GitHub, so I let the package's name be plain text.