### PR TITLE
Replace invalidated signatures in delocated libraries.

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE
 
 from .pycompat import string_types
 from .libsana import tree_libs, stripped_lib_dict, get_rp_stripper
-from .tools import (set_install_name, zip2dir, dir2zip,
+from .tools import (set_install_name, zip2dir, dir2zip, validate_signature,
                     find_package_dirs, set_install_id, get_archs)
 from .tmpdirs import TemporaryDirectory
 from .wheeltools import rewrite_record, InWheel
@@ -398,6 +398,7 @@ def delocate_wheel(in_wheel,
                 lib_base = basename(lib)
                 copied_path = pjoin(lib_path, lib_base)
                 set_install_id(copied_path, install_id_root + lib_base)
+                validate_signature(copied_path)
             _merge_lib_dict(all_copied, copied_libs)
         if len(all_copied):
             rewrite_record(wheel_dir)

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -253,6 +253,7 @@ def test_patch_wheel():
 
 def test_fix_rpath():
     # Test wheels which have an @rpath dependency
+    # Also verifies the delocated libraries signature
     with InTemporaryDirectory():
         # The module was set to expect its dependency in the libs/ directory
         os.symlink(DATA_PATH, 'libs')
@@ -268,3 +269,6 @@ def test_fix_rpath():
             delocate_wheel(RPATH_WHEEL, 'tmp.whl'),
             {stray_lib: {dep_mod: dep_path}},
         )
+        with InWheel('tmp.whl'):
+            check_call(['codesign', '--verify',
+                        'fakepkg/.dylibs/libextfunc_rpath.dylib'])


### PR DESCRIPTION
If a binary file is signed, tools like install_name_tool will invalidate
the signature by changing the file contents.  Later versions of MacOS
refuse to load binary files with invalid signatures.

This adds a new function which overwrites bad signatures with an ad-hoc
signature.  This is as close as you can get to removing the signature
using the available tools in MacOS.