### PR TITLE
BF: add fixes for latest otool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ matrix:
       - env: VERSION="3.6.1"
       # OS X 10.9
       - osx_image: beta-xcode6.1
+      # Xcode 9.1 OS X 10.12
+      - osx_image: xcode9.1
       # Xcode 8.3.2 OS X 10.12
       - osx_image: xcode8.3
-      # Xcode 8.2 OS X 10.12
-      - osx_image: xcode8.2
-      # Xcode 8.1 OS X 10.12
-      - osx_image: xcode8.1
       # Xcode 8gm OS X 10.11
       - osx_image: xcode8
       # Default Xcode 7.3.1 OS X 10.11

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include delocate/_version.py
 include LICENSE
 include README.rst
 include AUTHORS
+recursive-include delocate/tests/data *

--- a/delocate/tests/data/some_code.py
+++ b/delocate/tests/data/some_code.py
@@ -1,0 +1,5 @@
+# An example Python code file
+
+def func():
+    # Here is my function
+    return 1

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -27,6 +27,7 @@ LIBA_STATIC = pjoin(DATA_PATH, 'liba.a')
 A_OBJECT = pjoin(DATA_PATH, 'a.o')
 TEST_LIB = pjoin(DATA_PATH, 'test-lib')
 ICO_FILE = pjoin(DATA_PATH, 'icon.ico')
+PY_FILE = pjoin(DATA_PATH, 'some_code.py')
 
 def test_get_install_names():
     # Test install name listing
@@ -45,6 +46,8 @@ def test_get_install_names():
     assert_equal(get_install_names(LIBA_STATIC), ())
     # ico file triggers another error message and should also return an empty tuple
     assert_equal(get_install_names(ICO_FILE), ())
+    # Python file (__file__ above may be a pyc file)
+    assert_equal(get_install_names(PY_FILE), ())
 
 
 def test_parse_install_name():
@@ -100,9 +103,15 @@ def test_set_install_id():
     assert_raises(InstallNameError, set_install_id, TEST_LIB, 'libbof.dylib')
 
 
+def test_get_rpaths():
+    # Test fetch of rpaths
+    # Not dynamic libs, no rpaths
+    for fname in (LIBB, A_OBJECT, LIBA_STATIC, ICO_FILE, PY_FILE):
+        assert_equal(get_rpaths(fname), ())
+
+
 def test_add_rpath():
     # Test adding to rpath
-    assert_equal(get_rpaths(LIBB), ())
     with InTemporaryDirectory() as tmpdir:
         libfoo = pjoin(tmpdir, 'libfoo.dylib')
         shutil.copy2(LIBB, libfoo)

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -135,7 +135,7 @@ def parse_install_name(line):
 BAD_OBJECT_STRINGS = [
     'is not an object file',  # otool version cctools-862
     'The end of the file was unexpectedly encountered',  # cctools-862 (.ico)
-    'The file was not recognized as a valid object file.',  # cctools-895
+    'The file was not recognized as a valid object file',  # cctools-895
     'Object is not a Mach-O file type'  # cctools-900
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='delocate',
       package_data = {'delocate.tests':
                       [pjoin('data', '*.dylib'),
                        pjoin('data', '*.txt'),
+                       pjoin('data', '*.py'),
                        pjoin('data', 'liba.a'),
                        pjoin('data', 'a.o'),
                        pjoin('data', '*.whl'),


### PR DESCRIPTION
Latest otool (900) has different not-object error messages.

Refactor routines reading otool output to deal with these error
messages.  Refactor get_rpaths to use the more general machinery.