### PR TITLE
Install one copy of libs used by multiple extension modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ install:
         pip install cython;
         (cd wheel_makers && ./make_wheels.sh);
     fi
+  # Upload wheels to Rackspace container
+  - pip install wheelhouse-uploader
+  - python -m wheelhouse_uploader upload --local-folder
+        ${TRAVIS_BUILD_DIR}/delocate/tests/data/
+        --no-update-index
+        $WHEEL_SPEC
   - pip install .
 
 script:


### PR DESCRIPTION
If you have a package that contains multiple C extensions that depend on the same shared libraries, then `delocate-wheel` saves duplicate copies of all of the shared libraries. An example is shown below.

This makes for packages that are several times larger than necessary. This patch causes `delocate-wheel` to sweep up all of the dependencies and put them in a single directory, rather than creating duplicates.

The convention is based on the proposal in pypa/auditwheel#89 and pypa/auditwheel#90.

## Example

```
gs66-wintermute:wheelhouse lpsinger$ tar tf lalsuite-6.48-cp36-cp36m-macosx_10_13_x86_64.whl 
lalsuite-6.48.dist-info/RECORD
lalsuite-6.48.dist-info/metadata.json
lalsuite-6.48.dist-info/WHEEL
lalsuite-6.48.dist-info/DESCRIPTION.rst
lalsuite-6.48.dist-info/top_level.txt
lalsuite-6.48.dist-info/METADATA
lalsimulation/_lalsimulation.cpython-36m-darwin.so
lalsimulation/__init__.py
lalsimulation/git_version.py
lalsimulation/_lalsimulation.so
lalsimulation/lalsimulation.py
lalsimulation/.dylibs/liblalsimulation.16.dylib
lalsimulation/.dylibs/libz.1.2.11.dylib
lalsimulation/.dylibs/libhdf5_hl.100.dylib
lalsimulation/.dylibs/libfftw3f.3.dylib
lalsimulation/.dylibs/libgsl.23.dylib
lalsimulation/.dylibs/liblalsupport.11.dylib
lalsimulation/.dylibs/liblal.14.dylib
lalsimulation/.dylibs/libhdf5.101.dylib
lalsimulation/.dylibs/libfftw3.3.dylib
lalsimulation/.dylibs/libgslcblas.0.dylib
lalsimulation/.dylibs/libgcc_s.1.dylib
lalmetaio/lalmetaio.py
lalmetaio/__init__.py
lalmetaio/git_version.py
lalmetaio/_lalmetaio.so
lalmetaio/_lalmetaio.cpython-36m-darwin.so
lalmetaio/.dylibs/libz.1.2.11.dylib
lalmetaio/.dylibs/liblalmetaio.5.dylib
lalmetaio/.dylibs/libmetaio.1.dylib
lalmetaio/.dylibs/libhdf5_hl.100.dylib
lalmetaio/.dylibs/libfftw3f.3.dylib
lalmetaio/.dylibs/libgsl.23.dylib
lalmetaio/.dylibs/liblalsupport.11.dylib
lalmetaio/.dylibs/liblal.14.dylib
lalmetaio/.dylibs/libhdf5.101.dylib
lalmetaio/.dylibs/libfftw3.3.dylib
lalmetaio/.dylibs/libgslcblas.0.dylib
lalmetaio/.dylibs/libgcc_s.1.dylib
...
```