### PR TITLE
Process C extensions inside namespace packages

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -404,10 +404,10 @@ def find_package_dirs(root_path):
         an ``__init__.py`` file.  Paths prefixed by `root_path`
     """
     package_sdirs = set()
-    for entry in os.listdir(root_path):
-        fname = entry if root_path == '.' else pjoin(root_path, entry)
-        if isdir(fname) and exists(pjoin(fname, '__init__.py')):
-            package_sdirs.add(fname)
+    for dirpath, dirnames, filenames in os.walk(root_path):
+        if '__init__.py' in filenames:
+            package_sdirs.add(dirpath)
+            del dirnames[:]
     return package_sdirs
 
 


### PR DESCRIPTION
When a wheel contains subpackages of a namespace package, there is no `__init__.py` file for the namespace package, though its subpackage directories do contain `__init__.py` files.

When scanning the wheel for package directories, searching the root for directories that contain `__init__.py` files is insufficient because we will miss C extension modules that are subpackages of namespace packages.

Instead, we need to do a depth-first traversal of the directory tree and capture the most shallow directories that contain `__init__.py` files.