### PR TITLE
Handle C extensions not inside a package directory (at the root)

### DIFF
--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -4,12 +4,27 @@ Analyze library dependencies in paths and wheel files
 """
 
 import os
-from os.path import join as pjoin, realpath
+from os.path import join as pjoin, realpath, isfile
 
 import warnings
 
 from .tools import get_install_names, zip2dir, get_rpaths
 from .tmpdirs import TemporaryDirectory
+
+
+def _analyze_path(depending_libpath, lib_dict, filt_func):
+    if not filt_func is None and not filt_func(depending_libpath):
+        return
+    rpaths = get_rpaths(depending_libpath)
+    for install_name in get_install_names(depending_libpath):
+        lib_path = (install_name if install_name.startswith('@')
+                    else realpath(install_name))
+        lib_path = resolve_rpath(lib_path, rpaths)
+        if lib_path in lib_dict:
+            lib_dict[lib_path][depending_libpath] = install_name
+        else:
+            lib_dict[lib_path] = {depending_libpath: install_name}
+
 
 def tree_libs(start_path, filt_func=None):
     """ Return analysis of library dependencies within `start_path`
@@ -48,20 +63,13 @@ def tree_libs(start_path, filt_func=None):
     * http://matthew-brett.github.io/pydagogue/mac_runtime_link.html
     """
     lib_dict = {}
-    for dirpath, dirnames, basenames in os.walk(start_path):
-        for base in basenames:
-            depending_libpath = realpath(pjoin(dirpath, base))
-            if not filt_func is None and not filt_func(depending_libpath):
-                continue
-            rpaths = get_rpaths(depending_libpath)
-            for install_name in get_install_names(depending_libpath):
-                lib_path = (install_name if install_name.startswith('@')
-                            else realpath(install_name))
-                lib_path = resolve_rpath(lib_path, rpaths)
-                if lib_path in lib_dict:
-                    lib_dict[lib_path][depending_libpath] = install_name
-                else:
-                    lib_dict[lib_path] = {depending_libpath: install_name}
+    if isfile(start_path):
+        _analyze_path(start_path, lib_dict, filt_func)
+    else:
+        for dirpath, dirnames, basenames in os.walk(start_path):
+            for base in basenames:
+                depending_libpath = realpath(pjoin(dirpath, base))
+                _analyze_path(depending_libpath, lib_dict, filt_func)
     return lib_dict
 
 


### PR DESCRIPTION
@matthew-brett how's this look for an implementation? It's working for me but needs a few tests.

Root packages end up with a `.dylib<pkg>` directory for delocated libs, this mirrors what auditwheel does.