### PR TITLE
set S_IFREG (regular file) in ZipInfo.external_attr

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -375,7 +375,7 @@ def dir2zip(in_dir, zip_fname):
             info = zipfile.ZipInfo(in_fname)
             info.filename = relpath(in_fname, in_dir)
             # See https://stackoverflow.com/questions/434641/how-do-i-set-permissions-attributes-on-a-file-in-a-zip-file-using-pythons-zip/48435482#48435482
-            info.external_attr = chmod_perms(in_fname) << 16
+            info.external_attr = (chmod_perms(in_fname) | stat.S_IFREG) << 16
             with open_readable(in_fname, 'rb') as fobj:
                 contents = fobj.read()
             z.writestr(info, contents, zipfile.ZIP_DEFLATED)


### PR DESCRIPTION
Fixes https://github.com/matthew-brett/delocate/issues/42

When zipping the wheel, we need to set `stat.S_IFREG` (for regular files) in the `ZipInfo.external_attr` attribute.
If we don't do that, then upon installing the wheel with pip, any files that had executable flags (e.g. embedded executables) in the wheel will lose them.
Pip restores the execute permissions when uncompressing the wheel only if `stat.S_ISREG(mode)` is True:

https://github.com/pypa/pip/blob/35f098363983baebc13ffb84ded80b816d8fb246/src/pip/_internal/utils/misc.py#L488-L493