### PR TITLE
fix with recursive search

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -408,10 +408,10 @@ def find_package_dirs(root_path):
         an ``__init__.py`` file.  Paths prefixed by `root_path`
     """
     package_sdirs = set()
-    for entry in os.listdir(root_path):
-        fname = entry if root_path == '.' else pjoin(root_path, entry)
-        if isdir(fname) and exists(pjoin(fname, '__init__.py')):
-            package_sdirs.add(fname)
+    # use recursive search in case there's purelib or platlib layers
+    for entry in [dp for dp, _, _ in os.walk(os.path.expanduser(root_path))]:
+        if isdir(entry) and exists(pjoin(entry, '__init__.py')):
+            package_sdirs.add(entry)
     return package_sdirs
 
 


### PR DESCRIPTION
Solve problem here: https://github.com/matthew-brett/delocate/issues/49

The root cause is that `find_package_dirs` only list the level-1 dir of the wheel which in some cases are not sufficient. There are times `library` in inside `purelib` or `platlib`

