### PR TITLE
Update "not an object" table for cctools-949

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -165,6 +165,8 @@ BAD_OBJECT_TESTS = [
     lambda s: 'Invalid data was encountered while parsing the file' in s,
     # cctools-900
     lambda s : 'Object is not a Mach-O file type' in s,
+    # cctools-949
+    lambda s : 'object is not a Mach-O file type' in s,
     # File may not have read permissions
     lambda s : RE_PERM_DEN.search(s) is not None
 ]


### PR DESCRIPTION
Sometime between cctools-900 and cctools-949, the `otool` utility on
OS X made a one-character change in its 'this isn't an object file'
message.  The old message was:

'Object is not a Mach-O file type'

and the new one is

'object is not a Mach-O file type'.

I've added a new line to `BAD_OBJECT_TESTS` in tools.py to check for
the new version.