### PR TITLE
Doc limitation with top-level Py module structure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ External library is not bundled into wheel
 
 If your project is structured as a standalone Python module rather
 than package, ``delocate-wheel`` may not find the extension modules
-that you want to patch.::
+that you want to patch::
 
     $ delocate-wheel -w fixed_wheels -v my-wheel-name.whl
     Fixing: my-wheel-name.whl
@@ -224,7 +224,7 @@ To show this visually, this project layout will **not** work::
     ├── setup.py
     └── README.md
 
-Instead, `delocate-wheel` requires a project organized as a Python
+Instead, ``delocate-wheel`` requires a project organized as a Python
 package rather than single standalone module::
 
     ├── proj/

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,9 @@ I need to rebuild this wheel to link with dual-architecture libraries.
 Troubleshooting
 ===============
 
+DelocationError: "library does not exist"
+---------------------------------------
+
 When running ``delocate-wheel`` or its sister command ``delocate-path``, you
 may get errors like this::
 
@@ -201,6 +204,68 @@ This is not a problem specific to ``delocate``; you will need to do this to
 make sure that ``myext.so`` can load ``libme.dylib`` without ``libme.dylib``
 being in the current working directory.  For ``CMAKE`` builds you may want to
 check out CMAKE_INSTALL_NAME_DIR_.
+
+External library is not bundled into wheel
+------------------------------------------
+
+If your project is structured as a standalone Python module rather
+than package, ``delocate-wheel`` may not find the extension modules
+that you want to patch.::
+
+    $ delocate-wheel -w fixed_wheels -v my-wheel-name.whl
+    Fixing: my-wheel-name.whl
+
+The above output is missing a line indicating that an external
+shared library was copied into the wheel as intended.
+
+To show this visually, this project layout will **not** work::
+
+    ├── extension_module.cpp
+    ├── setup.py
+    └── README.md
+
+Instead, `delocate-wheel` requires a project organized as a Python
+package rather than single standalone module::
+
+    ├── proj/
+    │   ├── __init__.py
+    │   ├── extension_module.cpp
+    ├── setup.py
+    └── README.md
+
+Here, ``__init__.py`` contains::
+
+    from .extension_module import *
+
+Along with this, make sure to include the ``packages`` argument
+to ``setup()`` in ``setup.py``::
+
+    # setup.py
+    from setuptools import setup, find_packages
+
+    # ...
+
+    setup(
+        # ...
+        packages=find_packages(),  # or packages=["proj"]
+        # ...
+    )
+
+After these changes, you should see the dylibs successfully copied in::
+
+    $ delocate-wheel -w fixed_wheels -v my-wheel-name.whl
+    Fixing: my-wheel-name.whl
+    Copied to package .dylibs directory:
+      /usr/local/Cellar/package/1.0/lib/mylib.22.dylib
+
+Refer to `Issue 12`_, `Issue 15`_, and `Issue 45`_ for more detail.
+
+.. _Issue 12:
+   https://github.com/matthew-brett/delocate/issues/12
+.. _Issue 15:
+   https://github.com/matthew-brett/delocate/issues/15
+.. _Issue 45:
+   https://github.com/matthew-brett/delocate/issues/45
 
 ****
 Code

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ Troubleshooting
 ===============
 
 DelocationError: "library does not exist"
----------------------------------------
+-----------------------------------------
 
 When running ``delocate-wheel`` or its sister command ``delocate-path``, you
 may get errors like this::


### PR DESCRIPTION
As discussed in Issue #12, Issue #15, and elsewhere
delocate-wheel may ignore compiled extensions at the
top level of a wheel that are not part of a Python
package.  This documents that limitation and shows
how the package structure can be adjuste to fix it.