### PR TITLE
add escape of character in name of library

### DIFF
--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -203,6 +203,8 @@ def test_get_archs_fuse():
     with InTemporaryDirectory():
         lipo_fuse(LIB32, LIB64, 'anotherlib')
         assert_equal(get_archs('anotherlib'), ARCH_BOTH)
+        lipo_fuse(LIB32, LIB64, 'anotherlib++')
+        assert_equal(get_archs('anotherlib++'), ARCH_BOTH)
         lipo_fuse(LIB64, LIB32, 'anotherlib')
         assert_equal(get_archs('anotherlib'), ARCH_BOTH)
         shutil.copyfile(LIB32, 'libcopy32')

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -494,8 +494,8 @@ def get_archs(libname):
         assert len(lines) == 1
         line = lines[0]
     for reggie in (
-            'Non-fat file: {0} is architecture: (.*)'.format(libname),
-            'Architectures in the fat file: {0} are: (.*)'.format(libname)):
+            'Non-fat file: {0} is architecture: (.*)'.format(re.escape(libname)),
+            'Architectures in the fat file: {0} are: (.*)'.format(re.escape(libname))):
         reggie = re.compile(reggie)
         match = reggie.match(line)
         if match is not None:


### PR DESCRIPTION
Fix regexp to escape characters for names like `name++`