### PR TITLE
MRG: fix for Catalina otool; wheel binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     # travis encrypt -r matthew-brett/delocate WHEELHOUSE_UPLOADER_SECRET=<the api key>
     - secure: "BRc15pHO6+WwBh36X7KK4KFC+/hD7G3r5bmkKkWqUSrm1fhFkqDizj9V5g/9pGEcAl5FRLV0VZjTeceISfu2UhXxQxj4CkkTy7KYuSbZak2pEntfsDs7YBpQ3NHJ6ic8YdcWgptRXIQfmg/KPc9FsBIfLxJ2yVyyY7D9XpK+SvQ="
 
-# Default OSX (xcode image) is 10.11 (xcode 7.3.1) as of 2017-05-02
+# Default macOS (xcode image) is 10.13 (xcode 9.4.1) as of 2020-06-27
 # See: https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version
 
 matrix:
@@ -21,8 +21,8 @@ matrix:
       - env: MB_PYTHON_VERSION=3.8
       # Wheel API changes
       - env: WHEEL_SPEC="wheel==0.31.1"
-      # OS X 10.9
-      - osx_image: beta-xcode6.1
+      # Xcode 12.0 macOS 10.15.5
+      - osx_image: xcode12
       # Xcode 9.1 OS X 10.12
       - osx_image: xcode9.1
       # Xcode 8.3.2 OS X 10.12
@@ -33,6 +33,8 @@ matrix:
       - osx_image: xcode7.3
       # Xcode 6.4 OS X 10.10
       - osx_image: xcode6.4
+      # OS X 10.9
+      - osx_image: beta-xcode6.1
       - env:
           - MB_PYTHON_VERSION=2.7
           - BUILD_WHEELS=1

--- a/delocate/tests/test_fuse.py
+++ b/delocate/tests/test_fuse.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import sys
 from os.path import (join as pjoin, relpath, isdir, dirname, basename)
 import shutil
 
@@ -96,7 +97,7 @@ def test_fuse_wheels():
         zip2dir(wheel_base, 'fused_wheel')
         assert_same_tree('to_wheel', 'fused_wheel')
         # Check unpacking works on fused wheel
-        back_tick(['wheel', 'unpack', wheel_base])
+        back_tick([sys.executable, '-m', 'wheel', 'unpack', wheel_base])
         # Put lib into wheel
         shutil.copyfile(LIB64A, pjoin('from_wheel', 'fakepkg2', 'liba.a'))
         rewrite_record('from_wheel')

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -7,9 +7,9 @@ import stat
 import shutil
 
 from ..tools import (back_tick, unique_by_index, ensure_writable, chmod_perms,
-                     ensure_permissions, zip2dir, dir2zip, find_package_dirs,
-                     cmp_contents, get_archs, lipo_fuse, replace_signature,
-                     validate_signature, add_rpath)
+                     ensure_permissions, parse_install_name, zip2dir, dir2zip,
+                     find_package_dirs, cmp_contents, get_archs, lipo_fuse,
+                     replace_signature, validate_signature, add_rpath)
 
 from ..tmpdirs import InTemporaryDirectory
 
@@ -116,6 +116,20 @@ def test_ensure_writable():
         st = os.stat('test.bin')
         foo('test.bin')
         assert_equal(os.stat('test.bin'), st)
+
+
+def test_parse_install_name():
+    # otool on versions previous to Catalina
+    line0 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+            '(compatibility version 1.2.0, current version 1.11.0)')
+    name, cpver, cuver = (
+        '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore',
+        '1.2.0', '1.11.0')
+    assert parse_install_name(line0) == (name, cpver, cuver)
+    # otool on Catalina
+    line1 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+             '(compatibility version 1.2.0, current version 1.11.0, weak)')
+    assert parse_install_name(line1) == (name, cpver, cuver)
 
 
 def _write_file(filename, contents):

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -1,6 +1,7 @@
 """ Direct tests of fixes to wheels """
 
 import os
+import sys
 from os.path import (join as pjoin, basename, realpath, abspath, exists, isdir)
 import stat
 from glob import glob
@@ -127,7 +128,7 @@ def test_fix_plat():
         fixed_wheel, stray_lib = _fixed_wheel(tmpdir)
         assert_equal(delocate_wheel(fixed_wheel),
                      {_rp(stray_lib): {dep_mod: stray_lib}})
-        back_tick(['wheel', 'unpack', fixed_wheel])
+        back_tick([sys.executable, '-m', 'wheel', 'unpack', fixed_wheel])
         # Check that copied libraries have modified install_name_ids
         zip2dir(fixed_wheel, 'plat_pkg3')
         base_stray = basename(stray_lib)
@@ -275,7 +276,7 @@ def test_patch_wheel():
         with open(pjoin('wheel1', 'fakepkg2', '__init__.py'), 'rt') as fobj:
             assert_equal(fobj.read(), 'print("Am in init")\n')
         # Check that wheel unpack works
-        back_tick(['wheel', 'unpack', out_fname])
+        back_tick([sys.executable, '-m', 'wheel', 'unpack', out_fname])
         # Copy the original, check it doesn't have patch
         shutil.copyfile(PURE_WHEEL, 'copied.whl')
         zip2dir('copied.whl', 'wheel2')

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -126,9 +126,9 @@ open_rw = ensure_permissions(stat.S_IRUSR | stat.S_IWUSR)(open)
 # For backward compatibility
 ensure_writable = ensure_permissions()
 
-
+# otool on 10.15 appends more information after versions.
 IN_RE = re.compile(r"(.*) \(compatibility version (\d+\.\d+\.\d+), "
-                   r"current version (\d+\.\d+\.\d+)\)")
+                   r"current version (\d+\.\d+\.\d+)(?:, \w+)?\)")
 
 
 def parse_install_name(line):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for tests
+wheel


### PR DESCRIPTION
Fix for new format of Cataline otool output.

Fix for 'wheel' binary not on path.