### PR TITLE
Fix bug caused by special characters in file name

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -494,8 +494,8 @@ def get_archs(libname):
         assert len(lines) == 1
         line = lines[0]
     for reggie in (
-            'Non-fat file: {0} is architecture: (.*)'.format(libname),
-            'Architectures in the fat file: {0} are: (.*)'.format(libname)):
+            'Non-fat file: {0} is architecture: (.*)'.format(re.escape(libname)),
+            'Architectures in the fat file: {0} are: (.*)'.format(re.escape(libname))):
         reggie = re.compile(reggie)
         match = reggie.match(line)
         if match is not None:


### PR DESCRIPTION
Fixes a bug that is caused by characters in file names that are special in regular expressions. For example:

```python
>>> from delocate import tools
>>> libname = '/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/libstdc++.6.dylib'
>>> tools.get_archs(libname)
---------------------------------------------------------------------------
error                                     Traceback (most recent call last)
<ipython-input-1-81960593a7ed> in <module>
      1 from delocate import tools
      2 libname = '/usr/local/Cellar/gcc/10.2.0/lib/gcc/10/libstdc++.6.dylib'
----> 3 tools.get_archs(libname)

~/anaconda3/lib/python3.7/site-packages/delocate/tools.py in get_archs(libname)
    497             'Non-fat file: {0} is architecture: (.*)'.format(libname),
    498             'Architectures in the fat file: {0} are: (.*)'.format(libname)):
--> 499         reggie = re.compile(reggie)
    500         match = reggie.match(line)
    501         if match is not None:

~/anaconda3/lib/python3.7/re.py in compile(pattern, flags)
    232 def compile(pattern, flags=0):
    233     "Compile a regular expression pattern, returning a Pattern object."
--> 234     return _compile(pattern, flags)
    235 
    236 def purge():

~/anaconda3/lib/python3.7/re.py in _compile(pattern, flags)
    284     if not sre_compile.isstring(pattern):
    285         raise TypeError("first argument must be string or compiled pattern")
--> 286     p = sre_compile.compile(pattern, flags)
    287     if not (flags & DEBUG):
    288         if len(_cache) >= _MAXCACHE:

~/anaconda3/lib/python3.7/sre_compile.py in compile(p, flags)
    762     if isstring(p):
    763         pattern = p
--> 764         p = sre_parse.parse(p, flags)
    765     else:
    766         pattern = None

~/anaconda3/lib/python3.7/sre_parse.py in parse(str, flags, pattern)
    928 
    929     try:
--> 930         p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
    931     except Verbose:
    932         # the VERBOSE flag was switched on inside the pattern.  to be

~/anaconda3/lib/python3.7/sre_parse.py in _parse_sub(source, state, verbose, nested)
    424     while True:
    425         itemsappend(_parse(source, state, verbose, nested + 1,
--> 426                            not nested and not items))
    427         if not sourcematch("|"):
    428             break

~/anaconda3/lib/python3.7/sre_parse.py in _parse(source, state, verbose, nested, first)
    652             if item[0][0] in _REPEATCODES:
    653                 raise source.error("multiple repeat",
--> 654                                    source.tell() - here + len(this))
    655             if item[0][0] is SUBPATTERN:
    656                 group, add_flags, del_flags, p = item[0][1]

error: multiple repeat at position 62
```