### PR TITLE
Raise an exception on dependency resolution failures.

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -1,0 +1,43 @@
+name: Python linters
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  flake8:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install Flake8
+      run: |
+        pip install flake8
+    - name: Run Flake8
+      uses: suo/flake8-github-action@releases/v1
+      with:
+        checkName: 'flake8'  # NOTE: this needs to be the same as the job name.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mypy:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install MyPy
+      run: |
+        pip install mypy
+    - name: Install Delocate dependencies.
+      run: |
+        pip install pytest
+        python setup.py develop
+    - uses: kolonialno/mypy-action@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        max-errors: 0
+        paths: delocate

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 2.7
+
+[mypy-wheel.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
+# Skip incompatible sub-modules.
+follow_imports = skip
+
+[mypy-delocate._version]
+# Ignore delocate._version module.
+ignore_errors = True

--- a/delocate/__init__.py
+++ b/delocate/__init__.py
@@ -4,7 +4,7 @@ from .delocating import delocate_path, delocate_wheel, patch_wheel
 from .libsana import tree_libs, wheel_libs
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+__version__ = get_versions()['version']  # type: ignore
 del get_versions
 
 __all__ = ("delocate_path", "delocate_wheel", "patch_wheel", "tree_libs",

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -26,6 +26,7 @@ from delocate.wheeltools import add_platforms, WheelToolsError
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -16,6 +16,7 @@ from delocate.fuse import fuse_wheels
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL1 WHEEL2\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -15,6 +15,7 @@ from delocate.libsana import stripped_lib_dict
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_OR_PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_patch.py
+++ b/delocate/cmd/delocate_patch.py
@@ -16,6 +16,7 @@ from delocate import patch_wheel, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME PATCH_FNAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -12,6 +12,7 @@ from delocate import delocate_path, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function, absolute_import
 import os
 from os.path import join as pjoin, basename, exists, expanduser
 import sys
+from typing import List, Optional, Text
 
 from optparse import OptionParser, Option
 
@@ -16,6 +17,7 @@ from delocate import delocate_wheel, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)
@@ -52,6 +54,7 @@ def main():
             os.makedirs(wheel_dir)
     else:
         wheel_dir = None
+    require_archs = None  # type: Optional[List[Text]]
     if opts.require_archs is None:
         require_archs = [] if opts.check_archs else None
     elif ',' in opts.require_archs:

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -16,6 +16,7 @@ libraries.
 import os
 from os.path import (join as pjoin, exists, splitext, relpath, abspath)
 import shutil
+from typing import Container, Text
 
 from .tools import (zip2dir, dir2zip, cmp_contents, lipo_fuse,
                     open_rw, chmod_perms)
@@ -24,6 +25,7 @@ from .wheeltools import rewrite_record
 
 
 def _copyfile(in_fname, out_fname):
+    # type: (Text, Text) -> None
     # Copies files without read / write permission
     perms = chmod_perms(in_fname)
     with open_rw(in_fname, 'rb') as fobj:
@@ -34,6 +36,7 @@ def _copyfile(in_fname, out_fname):
 
 
 def fuse_trees(to_tree, from_tree, lib_exts=('.so', '.dylib', '.a')):
+    # type: (Text, Text, Container[Text]) -> None
     """ Fuse path `from_tree` into path `to_tree`
 
     For each file in `from_tree` - check for library file extension (in
@@ -78,6 +81,7 @@ def fuse_trees(to_tree, from_tree, lib_exts=('.so', '.dylib', '.a')):
 
 
 def fuse_wheels(to_wheel, from_wheel, out_wheel):
+    # type: (Text, Text, Text) -> None
     """ Fuse `from_wheel` into `to_wheel`, write to `out_wheel`
 
     Parameters

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -6,6 +6,8 @@ Analyze library dependencies in paths and wheel files
 import os
 from os.path import basename, join as pjoin, realpath
 
+import warnings
+
 from .tools import (get_install_names, zip2dir, get_rpaths,
                     get_environment_variable_paths)
 from .tmpdirs import TemporaryDirectory
@@ -53,6 +55,11 @@ def tree_libs(start_path, filt_func=None, skip_missing=False):
     DependencyNotFound
         When any `@rpath` dependencies can not be located and `skip_missing`
         is False.
+
+    Warns
+    -----
+    UserWarning
+        Instead of DependencyNotFound when `skip_missing` is True.
 
     Notes
     -----
@@ -105,8 +112,12 @@ def tree_libs(start_path, filt_func=None, skip_missing=False):
             )
         raise DependencyNotFound(error_msg)
 
-    for missing, _, _ in missing_dependencies:
-        print("Ignoring missing dependency: {0}".format(missing))
+    if missing_dependencies:
+        warnings.warn(
+            "Ignored missing dependencies:\n  {0}".format(
+                "\n  ".join(missing for missing, _, _ in missing_dependencies),
+            )
+        )
 
     return lib_dict
 

--- a/delocate/tests/env_tools.py
+++ b/delocate/tests/env_tools.py
@@ -1,19 +1,24 @@
 from contextlib import contextmanager
 import os
+from typing import Iterator, Text
+
+import six
 
 from ..tmpdirs import InTemporaryDirectory
 
 
 @contextmanager
 def TempDirWithoutEnvVars(*env_vars):
+    # type: (*Text) -> Iterator[Text]
     """ Remove `env_vars` from the environment and restore them after
     testing is complete.
     """
     old_vars = {}
     for var in env_vars:
-        old_vars[var] = os.environ.get(var, None)
-        if old_vars[var] is not None:
-            del os.environ[var]
+        try:
+            old_vars[six.ensure_str(var)] = os.environ[six.ensure_str(var)]
+        except KeyError:
+            pass
     try:
         with InTemporaryDirectory() as tmpdir:
             yield tmpdir

--- a/delocate/tests/pytest_tools.py
+++ b/delocate/tests/pytest_tools.py
@@ -1,26 +1,33 @@
+from typing import Any
+
 import pytest
 
 
 def assert_true(condition):
+    # type: (Any) -> None
     __tracebackhide__ = True
     assert condition
 
 
 def assert_false(condition):
+    # type: (Any) -> None
     __tracebackhide__ = True
     assert not condition
 
 
 def assert_raises(expected_exception, *args, **kwargs):
+    # type: (Any, *Any, **Any) -> Any
     __tracebackhide__ = True
     return pytest.raises(expected_exception, *args, **kwargs)
 
 
 def assert_equal(first, second):
+    # type: (Any, Any) -> None
     __tracebackhide__ = True
     assert first == second
 
 
 def assert_not_equal(first, second):
+    # type: (Any, Any) -> None
     __tracebackhide__ = True
     assert first != second

--- a/delocate/tests/test_fuse.py
+++ b/delocate/tests/test_fuse.py
@@ -5,8 +5,9 @@ import os
 import sys
 from os.path import (join as pjoin, relpath, isdir, dirname, basename)
 import shutil
+from typing import Iterable, Text
 
-from ..tools import (cmp_contents, get_archs, zip2dir, dir2zip, back_tick,
+from ..tools import (cmp_contents, get_archs, zip2dir, dir2zip, check_call,
                      open_readable)
 from ..fuse import fuse_trees, fuse_wheels
 from ..tmpdirs import InTemporaryDirectory
@@ -20,6 +21,7 @@ from .test_wheeltools import assert_record_equal
 
 
 def assert_same_tree(tree1, tree2):
+    # type: (Text, Text) -> None
     for dirpath, dirnames, filenames in os.walk(tree1):
         tree2_dirpath = pjoin(tree2, relpath(dirpath, tree1))
         for dname in dirnames:
@@ -37,10 +39,12 @@ def assert_same_tree(tree1, tree2):
 
 
 def assert_listdir_equal(path, listing):
+    # type: (Text, Iterable[Text]) -> None
     assert sorted(os.listdir(path)) == sorted(listing)
 
 
 def test_fuse_trees():
+    # type: () -> None
     # Test function to fuse two paths
     with InTemporaryDirectory():
         os.mkdir('tree1')
@@ -86,6 +90,7 @@ def test_fuse_trees():
 
 
 def test_fuse_wheels():
+    # type: () -> None
     # Test function to fuse two wheels
     wheel_base = basename(PURE_WHEEL)
     with InTemporaryDirectory():
@@ -97,7 +102,7 @@ def test_fuse_wheels():
         zip2dir(wheel_base, 'fused_wheel')
         assert_same_tree('to_wheel', 'fused_wheel')
         # Check unpacking works on fused wheel
-        back_tick([sys.executable, '-m', 'wheel', 'unpack', wheel_base])
+        check_call([sys.executable, '-m', 'wheel', 'unpack', wheel_base])
         # Put lib into wheel
         shutil.copyfile(LIB64A, pjoin('from_wheel', 'fakepkg2', 'liba.a'))
         rewrite_record('from_wheel')

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -4,6 +4,7 @@ import os
 from os.path import (join as pjoin, exists, dirname, basename)
 
 import shutil
+from typing import Iterable, List, Text
 
 from ..tools import (InstallNameError, get_install_names, set_install_name,
                      get_install_id, get_rpaths, add_rpath, parse_install_name,
@@ -15,23 +16,24 @@ from .pytest_tools import (assert_raises, assert_equal)
 from .env_tools import TempDirWithoutEnvVars
 
 # External libs linked from test data
-LIBSTDCXX = '/usr/lib/libstdc++.6.dylib'
-LIBSYSTEMB = '/usr/lib/libSystem.B.dylib'
+LIBSTDCXX = u'/usr/lib/libstdc++.6.dylib'
+LIBSYSTEMB = u'/usr/lib/libSystem.B.dylib'
 EXT_LIBS = (LIBSTDCXX, LIBSYSTEMB)
 
-DATA_PATH = pjoin(dirname(__file__), 'data')
-LIBA = pjoin(DATA_PATH, 'liba.dylib')
-LIBB = pjoin(DATA_PATH, 'libb.dylib')
-LIBC = pjoin(DATA_PATH, 'libc.dylib')
-LIBA_STATIC = pjoin(DATA_PATH, 'liba.a')
-A_OBJECT = pjoin(DATA_PATH, 'a.o')
-TEST_LIB = pjoin(DATA_PATH, 'test-lib')
-ICO_FILE = pjoin(DATA_PATH, 'icon.ico')
-PY_FILE = pjoin(DATA_PATH, 'some_code.py')
-BIN_FILE = pjoin(DATA_PATH, 'binary_example.bin')
+DATA_PATH = pjoin(dirname(__file__), u'data')
+LIBA = pjoin(DATA_PATH, u'liba.dylib')
+LIBB = pjoin(DATA_PATH, u'libb.dylib')
+LIBC = pjoin(DATA_PATH, u'libc.dylib')
+LIBA_STATIC = pjoin(DATA_PATH, u'liba.a')
+A_OBJECT = pjoin(DATA_PATH, u'a.o')
+TEST_LIB = pjoin(DATA_PATH, u'test-lib')
+ICO_FILE = pjoin(DATA_PATH, u'icon.ico')
+PY_FILE = pjoin(DATA_PATH, u'some_code.py')
+BIN_FILE = pjoin(DATA_PATH, u'binary_example.bin')
 
 
 def test_get_install_names():
+    # type: () -> None
     # Test install name listing
     assert_equal(set(get_install_names(LIBA)),
                  set(EXT_LIBS))
@@ -63,6 +65,7 @@ def test_get_install_names():
 
 
 def test_parse_install_name():
+    # type: () -> None
     assert_equal(parse_install_name(
         "liba.dylib (compatibility version 0.0.0, current version 0.0.0)"),
         ("liba.dylib", "0.0.0", "0.0.0"))
@@ -77,6 +80,7 @@ def test_parse_install_name():
 
 
 def test_install_id():
+    # type: () -> None
     # Test basic otool library listing
     assert_equal(get_install_id(LIBA), 'liba.dylib')
     assert_equal(get_install_id(LIBB), 'libb.dylib')
@@ -88,6 +92,7 @@ def test_install_id():
 
 
 def test_change_install_name():
+    # type: () -> None
     # Test ability to change install names in library
     libb_names = get_install_names(LIBB)
     with InTemporaryDirectory() as tmpdir:
@@ -103,6 +108,7 @@ def test_change_install_name():
 
 
 def test_set_install_id():
+    # type: () -> None
     # Test ability to change install id in library
     liba_id = get_install_id(LIBA)
     with InTemporaryDirectory() as tmpdir:
@@ -116,6 +122,7 @@ def test_set_install_id():
 
 
 def test_get_rpaths():
+    # type: () -> None
     # Test fetch of rpaths
     # Not dynamic libs, no rpaths
     for fname in (LIBB, A_OBJECT, LIBA_STATIC, ICO_FILE, PY_FILE, BIN_FILE):
@@ -123,6 +130,7 @@ def test_get_rpaths():
 
 
 def test_get_environment_variable_paths():
+    # type: () -> None
     # Test that environment variable paths are fetched in a specific order
     with TempDirWithoutEnvVars('DYLD_FALLBACK_LIBRARY_PATH',
                                'DYLD_LIBRARY_PATH'):
@@ -132,6 +140,7 @@ def test_get_environment_variable_paths():
 
 
 def test_add_rpath():
+    # type: () -> None
     # Test adding to rpath
     with InTemporaryDirectory() as tmpdir:
         libfoo = pjoin(tmpdir, 'libfoo.dylib')
@@ -144,6 +153,7 @@ def test_add_rpath():
 
 
 def _copy_libs(lib_files, out_path):
+    # type: (Iterable[Text], Text) -> List[Text]
     copied = []
     if not exists(out_path):
         os.makedirs(out_path)

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -7,13 +7,14 @@ import os
 from os.path import (join as pjoin, dirname, realpath, relpath, split)
 
 from ..libsana import (tree_libs, get_prefix_stripper, get_rp_stripper,
-                       stripped_lib_dict, wheel_libs, resolve_rpath)
+                       stripped_lib_dict, wheel_libs, resolve_rpath,
+                       DependencyNotFound)
 
 from ..tools import set_install_name
 
 from ..tmpdirs import InTemporaryDirectory
 
-from .pytest_tools import assert_equal
+from .pytest_tools import assert_equal, assert_raises
 
 from .test_install_names import (LIBA, LIBB, LIBC, TEST_LIB, _copy_libs,
                                  EXT_LIBS, LIBSYSTEMB)
@@ -182,5 +183,5 @@ def test_resolve_rpath():
     lib_rpath = pjoin('@rpath', lib)
     # Should skip '/nonexist' path
     assert_equal(resolve_rpath(lib_rpath, ['/nonexist', path]), realpath(LIBA))
-    # Should return the given parameter as is since it can't be found
-    assert_equal(resolve_rpath(lib_rpath, []), lib_rpath)
+    # Should raise DependencyNotFound if the dependency can not be resolved.
+    assert_raises(DependencyNotFound, lambda: resolve_rpath(lib_rpath, []))

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -193,6 +193,10 @@ def test_resolve_rpath():
     path, lib = split(LIBA)
     lib_rpath = pjoin('@rpath', lib)
     # Should skip '/nonexist' path
-    assert_equal(resolve_rpath(lib_rpath, ['/nonexist', path]), realpath(LIBA))
+    assert_equal(
+        resolve_rpath(lib_rpath, ['/nonexist', path], path), realpath(LIBA)
+    )
     # Should raise DependencyNotFound if the dependency can not be resolved.
-    assert_raises(DependencyNotFound, lambda: resolve_rpath(lib_rpath, []))
+    assert_raises(
+        DependencyNotFound, lambda: resolve_rpath(lib_rpath, [], path)
+    )

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -5,6 +5,7 @@ Utilities for analyzing library dependencies in trees and wheels
 
 import os
 from os.path import (join as pjoin, dirname, realpath, relpath, split)
+from typing import Dict, Iterable, Text
 
 from ..libsana import (tree_libs, get_prefix_stripper, get_rp_stripper,
                        stripped_lib_dict, wheel_libs, resolve_rpath,
@@ -22,6 +23,7 @@ from .test_wheelies import (PLAT_WHEEL, PURE_WHEEL, STRAY_LIB_DEP)
 
 
 def get_ext_dict(local_libs):
+    # type: (Iterable[Text]) -> Dict[Text, Dict[Text, Text]]
     ext_deps = {}
     for ext_lib in EXT_LIBS:
         lib_deps = {}
@@ -32,6 +34,7 @@ def get_ext_dict(local_libs):
 
 
 def test_tree_libs():
+    # type: () -> None
     # Test ability to walk through tree, finding dynamic libary refs
     # Copy specific files to avoid working tree cruft
     to_copy = [LIBA, LIBB, LIBC, TEST_LIB]
@@ -49,6 +52,7 @@ def test_tree_libs():
         assert_equal(tree_libs(tmpdir), exp_dict)
 
         def filt(fname):
+            # type: (Text) -> bool
             return fname.endswith('.dylib')
         exp_dict = get_ext_dict([liba, libb, libc])
         exp_dict.update({
@@ -96,6 +100,7 @@ def test_tree_libs():
 
 
 def test_get_prefix_stripper():
+    # type: () -> None
     # Test function factory to strip prefixes
     f = get_prefix_stripper('')
     assert_equal(f('a string'), 'a string')
@@ -106,6 +111,7 @@ def test_get_prefix_stripper():
 
 
 def test_get_rp_stripper():
+    # type: () -> None
     # realpath prefix stripper
     # Just does realpath and adds path sep
     cwd = realpath(os.getcwd())
@@ -119,6 +125,7 @@ def test_get_rp_stripper():
 
 
 def get_ext_dict_stripped(local_libs, start_path):
+    # type: (Iterable[Text], Text) -> Dict[Text, Dict[Text, Text]]
     ext_dict = {}
     for ext_lib in EXT_LIBS:
         lib_deps = {}
@@ -132,6 +139,7 @@ def get_ext_dict_stripped(local_libs, start_path):
 
 
 def test_stripped_lib_dict():
+    # type: () -> None
     # Test routine to return lib_dict with relative paths
     to_copy = [LIBA, LIBB, LIBC, TEST_LIB]
     with InTemporaryDirectory() as tmpdir:
@@ -165,6 +173,7 @@ def test_stripped_lib_dict():
 
 
 def test_wheel_libs():
+    # type: () -> None
     # Test routine to list dependencies from wheels
     assert_equal(wheel_libs(PURE_WHEEL), {})
     mod2 = pjoin('fakepkg1', 'subpkg', 'module2.so')
@@ -173,11 +182,13 @@ def test_wheel_libs():
                   realpath(LIBSYSTEMB): {mod2: LIBSYSTEMB}})
 
     def filt(fname):
+        # type: (Text) -> bool
         return not fname.endswith(mod2)
     assert_equal(wheel_libs(PLAT_WHEEL, filt), {})
 
 
 def test_resolve_rpath():
+    # type: () -> None
     # A minimal test of the resolve_rpath function
     path, lib = split(LIBA)
     lib_rpath = pjoin('@rpath', lib)

--- a/delocate/tests/test_tmpdirs.py
+++ b/delocate/tests/test_tmpdirs.py
@@ -13,6 +13,7 @@ MY_DIR = dirname(MY_PATH)
 
 
 def test_given_directory():
+    # type: () -> None
     # Test InGivenDirectory
     cwd = getcwd()
     with InGivenDirectory() as tmpdir:

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -5,28 +5,40 @@ import os
 from os.path import join as pjoin, dirname
 import stat
 import shutil
+from typing import Iterator, Text
 
 from ..tools import (back_tick, unique_by_index, ensure_writable, chmod_perms,
                      ensure_permissions, parse_install_name, zip2dir, dir2zip,
                      find_package_dirs, cmp_contents, get_archs, lipo_fuse,
-                     replace_signature, validate_signature, add_rpath)
+                     replace_signature, validate_signature, add_rpath,
+                     run_call, check_call)
 
 from ..tmpdirs import InTemporaryDirectory
 
 from .pytest_tools import assert_true, assert_false, assert_equal, \
     assert_raises
 
-DATA_PATH = pjoin(dirname(__file__), 'data')
-LIB32 = pjoin(DATA_PATH, 'liba32.dylib')
-LIB64 = pjoin(DATA_PATH, 'liba.dylib')
-LIBBOTH = pjoin(DATA_PATH, 'liba_both.dylib')
-LIB64A = pjoin(DATA_PATH, 'liba.a')
-ARCH_64 = frozenset(['x86_64'])
-ARCH_32 = frozenset(['i386'])
+DATA_PATH = pjoin(dirname(__file__), u'data')
+LIB32 = pjoin(DATA_PATH, u'liba32.dylib')
+LIB64 = pjoin(DATA_PATH, u'liba.dylib')
+LIBBOTH = pjoin(DATA_PATH, u'liba_both.dylib')
+LIB64A = pjoin(DATA_PATH, u'liba.a')
+ARCH_64 = frozenset([u'x86_64'])
+ARCH_32 = frozenset([u'i386'])
 ARCH_BOTH = ARCH_64 | ARCH_32
 
 
+def test_call():
+    # type: () -> None
+    cmd = 'python -c "print(\'Hello\')"'
+    assert_equal(check_call(cmd), "Hello")
+    assert_equal(run_call(cmd), (0, "Hello", ""))
+    cmd = 'python -c "raise ValueError()"'
+    assert_raises(RuntimeError, check_call, cmd)
+
+
 def test_back_tick():
+    # type: () -> None
     cmd = 'python -c "print(\'Hello\')"'
     assert_equal(back_tick(cmd), "Hello")
     assert_equal(back_tick(cmd, ret_err=True), ("Hello", ""))
@@ -36,6 +48,7 @@ def test_back_tick():
 
 
 def test_uniqe_by_index():
+    # type: () -> None
     assert_equal(unique_by_index([1, 2, 3, 4]),
                  [1, 2, 3, 4])
     assert_equal(unique_by_index([1, 2, 2, 4]),
@@ -44,6 +57,7 @@ def test_uniqe_by_index():
                  [4, 2, 1])
 
     def gen():
+        # type: () -> Iterator[int]
         yield 4
         yield 2
         yield 2
@@ -52,6 +66,7 @@ def test_uniqe_by_index():
 
 
 def test_ensure_permissions():
+    # type: () -> None
     # Test decorator to ensure permissions
     with InTemporaryDirectory():
         # Write, set zero permissions
@@ -64,6 +79,7 @@ def test_ensure_permissions():
             sts[fname] = chmod_perms(fname)
 
         def read_file(fname):
+            # type: (Text) -> Text
             with open(fname, 'rt') as fobj:
                 contents = fobj.read()
             return contents
@@ -72,6 +88,7 @@ def test_ensure_permissions():
         non_read_file = ensure_permissions(stat.S_IWUSR)(read_file)
 
         def write_file(fname, contents):
+            # type: (Text, str) -> None
             with open(fname, 'wt') as fobj:
                 fobj.write(contents)
 
@@ -99,6 +116,7 @@ def test_ensure_permissions():
 
 
 def test_ensure_writable():
+    # type: () -> None
     # Test ensure writable decorator
     with InTemporaryDirectory():
         with open('test.bin', 'wt') as fobj:
@@ -106,8 +124,10 @@ def test_ensure_writable():
         # Set to user rw, else r
         os.chmod('test.bin', 0o644)
         st = os.stat('test.bin')
+
         @ensure_writable
         def foo(fname):
+            # type: (Text) -> None
             pass
         foo('test.bin')
         assert_equal(os.stat('test.bin'), st)
@@ -119,25 +139,30 @@ def test_ensure_writable():
 
 
 def test_parse_install_name():
+    # type: () -> None
     # otool on versions previous to Catalina
-    line0 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
-            '(compatibility version 1.2.0, current version 1.11.0)')
+    line0 = (
+        '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+        '(compatibility version 1.2.0, current version 1.11.0)')
     name, cpver, cuver = (
         '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore',
         '1.2.0', '1.11.0')
     assert parse_install_name(line0) == (name, cpver, cuver)
     # otool on Catalina
-    line1 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
-             '(compatibility version 1.2.0, current version 1.11.0, weak)')
+    line1 = (
+        '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+        '(compatibility version 1.2.0, current version 1.11.0, weak)')
     assert parse_install_name(line1) == (name, cpver, cuver)
 
 
 def _write_file(filename, contents):
+    # type: (Text, str) -> None
     with open(filename, 'wt') as fobj:
         fobj.write(contents)
 
 
 def test_zip2():
+    # type: () -> None
     # Test utilities to unzip and zip up
     with InTemporaryDirectory():
         os.mkdir('a_dir')
@@ -170,6 +195,7 @@ def test_zip2():
 
 
 def test_find_package_dirs():
+    # type: () -> None
     # Test utility for finding package directories
     with InTemporaryDirectory():
         os.mkdir('to_test')
@@ -191,6 +217,7 @@ def test_find_package_dirs():
 
 
 def test_cmp_contents():
+    # type: () -> None
     # Binary compare of filenames
     assert_true(cmp_contents(__file__, __file__))
     with InTemporaryDirectory():
@@ -208,6 +235,7 @@ def test_cmp_contents():
 
 
 def test_get_archs_fuse():
+    # type: () -> None
     # Test routine to get architecture types from file
     assert_equal(get_archs(LIB32), ARCH_32)
     assert_equal(get_archs(LIB64), ARCH_64)
@@ -232,10 +260,12 @@ def test_get_archs_fuse():
 
 
 def test_validate_signature():
+    # type: () -> None
     # Fully test the validate_signature tool
     def check_signature(filename):
+        # type: (Text) -> None
         """Raises RuntimeError if codesign can not verify the signature."""
-        back_tick(['codesign', '--verify', filename], raise_err=True)
+        check_call(['codesign', '--verify', filename])
 
     with InTemporaryDirectory():
         # Copy a binary file to test with, any binary file would work

--- a/delocate/tmpdirs.py
+++ b/delocate/tmpdirs.py
@@ -13,6 +13,8 @@ from __future__ import division, print_function, absolute_import
 import os
 import shutil
 from tempfile import template, mkdtemp
+from typing import Any, Optional, Text
+from typing_extensions import Literal
 
 
 class TemporaryDirectory(object):
@@ -33,18 +35,22 @@ class TemporaryDirectory(object):
     False
     """
     def __init__(self, suffix="", prefix=template, dir=None):
+        # type: (Text, Text, Optional[Text]) -> None
         self.name = mkdtemp(suffix, prefix, dir)
         self._closed = False
 
     def __enter__(self):
+        # type: () -> Text
         return self.name
 
     def cleanup(self):
+        # type: () -> None
         if not self._closed:
             shutil.rmtree(self.name)
             self._closed = True
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
         self.cleanup()
         return False
 
@@ -66,11 +72,13 @@ class InTemporaryDirectory(TemporaryDirectory):
     True
     '''
     def __enter__(self):
+        # type: () -> Text
         self._pwd = os.getcwd()
         os.chdir(self.name)
         return super(InTemporaryDirectory, self).__enter__()
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
         os.chdir(self._pwd)
         return super(InTemporaryDirectory, self).__exit__(exc, value, tb)
 
@@ -99,6 +107,7 @@ class InGivenDirectory(object):
     again.
     """
     def __init__(self, path=None):
+        # type: (Optional[Text]) -> None
         """ Initialize directory context manager
 
         Parameters
@@ -112,6 +121,7 @@ class InGivenDirectory(object):
         self.path = os.path.abspath(path)
 
     def __enter__(self):
+        # type: () -> Text
         self._pwd = os.path.abspath(os.getcwd())
         if not os.path.isdir(self.path):
             os.mkdir(self.path)
@@ -119,4 +129,5 @@ class InGivenDirectory(object):
         return self.path
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> None
         os.chdir(self._pwd)

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -11,6 +11,9 @@ import glob
 import hashlib
 import csv
 from itertools import product
+from typing import (Any, BinaryIO, Iterable, Iterator, Optional, Text, TypeVar,
+                    Union)
+from typing_extensions import Literal
 
 from wheel.util import urlsafe_b64encode, native
 from wheel.pkginfo import read_pkg_info, write_pkg_info
@@ -27,6 +30,7 @@ class WheelToolsError(Exception):
 
 
 def _open_for_csv(name, mode):
+    # type: (Text, Text) -> BinaryIO
     """ Deal with Python 2/3 open API differences """
     if sys.version_info[0] < 3:
         return open_rw(name, mode + 'b')
@@ -34,6 +38,7 @@ def _open_for_csv(name, mode):
 
 
 def rewrite_record(bdist_dir):
+    # type: (Text) -> None
     """ Rewrite RECORD file with hashes for all files in `wheel_sdir`
 
     Copied from :method:`wheel.bdist_wheel.bdist_wheel.write_record`
@@ -56,11 +61,13 @@ def rewrite_record(bdist_dir):
         os.unlink(sig_path)
 
     def walk():
+        # type: () -> Iterator[Text]
         for dir, dirs, files in os.walk(bdist_dir):
             for f in files:
                 yield pjoin(dir, f)
 
     def skip(path):
+        # type: (Text) -> bool
         """Wheel hashes every possible file."""
         return (path == record_relpath)
 
@@ -70,7 +77,7 @@ def rewrite_record(bdist_dir):
             relative_path = relpath(path, bdist_dir)
             if skip(relative_path):
                 hash = ''
-                size = ''
+                size = ''  # type: Union[str, int]
             else:
                 with open(path, 'rb') as f:
                     data = f.read()
@@ -89,7 +96,8 @@ class InWheel(InTemporaryDirectory):
     asked for an output wheel, then on exit we'll rewrite the wheel record and
     pack stuff up for you.
     """
-    def __init__(self, in_wheel, out_wheel=None, ret_self=False):
+    def __init__(self, in_wheel, out_wheel=None):
+        # type: (Text, Optional[Text]) -> None
         """ Initialize in-wheel context manager
 
         Parameters
@@ -99,26 +107,28 @@ class InWheel(InTemporaryDirectory):
         out_wheel : None or str:
             filename of wheel to write after exiting.  If None, don't write and
             discard
-        ret_self : bool, optional
-            If True, return ``self`` from ``__enter__``, otherwise return the
-            directory path.
         """
         self.in_wheel = abspath(in_wheel)
         self.out_wheel = None if out_wheel is None else abspath(out_wheel)
         super(InWheel, self).__init__()
 
     def __enter__(self):
+        # type: () -> Text
         zip2dir(self.in_wheel, self.name)
         return super(InWheel, self).__enter__()
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
         if self.out_wheel is not None:
             rewrite_record(self.name)
             dir2zip(self.name, self.out_wheel)
         return super(InWheel, self).__exit__(exc, value, tb)
 
 
-class InWheelCtx(InWheel):
+WHEELCTX_T = TypeVar("WHEELCTX_T", bound="InWheelCtx")
+
+
+class InWheelCtx(object):
     """ Context manager for doing things inside wheels
 
     On entering, you'll find yourself in the root tree of the wheel.  If you've
@@ -127,14 +137,15 @@ class InWheelCtx(InWheel):
 
     The context manager returns itself from the __enter__ method, so you can
     set things like ``out_wheel``.  This is useful when processing in the wheel
-    will dicate what the output wheel name is, or whether you want to save at
+    will dictate what the output wheel name is, or whether you want to save at
     all.
 
     The current path of the wheel contents is set in the attribute
     ``wheel_path``.
     """
     def __init__(self, in_wheel, out_wheel=None):
-        """ Init in-wheel context manager returning self from enter
+        # type: (Text, Optional[Text]) -> None
+        """ Initialize in-wheel context manager
 
         Parameters
         ----------
@@ -144,15 +155,45 @@ class InWheelCtx(InWheel):
             filename of wheel to write after exiting.  If None, don't write and
             discard
         """
-        super(InWheelCtx, self).__init__(in_wheel, out_wheel)
-        self.wheel_path = None
+        self.inwheel = InWheel(in_wheel, out_wheel)
 
-    def __enter__(self):
-        self.wheel_path = super(InWheelCtx, self).__enter__()
+    def __enter__(
+        self  # type: WHEELCTX_T
+    ):
+        # type: (...) -> WHEELCTX_T
+        self.inwheel.__enter__()
         return self
+
+    def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
+        return self.inwheel.__exit__(exc, value, tb)
+
+    @property
+    def wheel_path(self):
+        # type: () -> Text
+        """ The path to the unpacked files from this wheel. """
+        return self.inwheel.name
+
+    @property
+    def in_wheel(self):
+        # type: () -> Text
+        """ The path of the wheel being worked on. """
+        return self.inwheel.in_wheel
+
+    @property
+    def out_wheel(self):
+        # type: () -> Optional[Text]
+        """ The file path to write to on closing. """
+        return self.inwheel.out_wheel
+
+    @out_wheel.setter
+    def out_wheel(self, value):
+        # type: (Optional[Text]) -> None
+        self.inwheel.out_wheel = value
 
 
 def _get_wheelinfo_name(wheelfile):
+    # type: (WheelFile) -> Text
     # Work round wheel API compatibility
     try:
         return wheelfile.wheelinfo_name
@@ -161,6 +202,7 @@ def _get_wheelinfo_name(wheelfile):
 
 
 def add_platforms(in_wheel, platforms, out_path=None, clobber=False):
+    # type: (Text, Iterable[Text], Optional[Text], bool) -> Optional[Text]
     """ Add platform tags `platforms` to `in_wheel` filename and WHEEL tags
 
     Add any platform tags in `platforms` that are missing from `in_wheel`

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(name='delocate',
           "machomachomangler; sys_platform == 'win32'",
           "bindepend; sys_platform == 'win32'",
           "wheel",
+          "six",
+          "typing; python_version < '3.5'",
+          "typing_extensions",
       ],
       package_data={'delocate.tests':
                     [pjoin('data', '*.dylib'),
@@ -44,7 +47,9 @@ setup(name='delocate',
                      pjoin('data', 'test-lib'),
                      pjoin('data', '*patch'),
                      pjoin('data', 'make_libs.sh'),
-                     pjoin('data', 'icon.ico')]},
+                     pjoin('data', 'icon.ico')],
+                    'delocate': ['py.typed'],
+                    },
       entry_points={
           'console_scripts': [
               'delocate-{} = delocate.cmd.delocate_{}:main'.format(name, name)


### PR DESCRIPTION
This only affects libraries with `@rpath` dependencies.  It's also me fixing my own bad code when I wrote resolve_rpath.  At least I knew this could be a problem back then and added a warning for it.

Previously this issue was warned about using Python's warning module, but these errors are more often critical and will affect the compatibility of the wheel.  A failure here means that either the library actually is missing, delocate is not being correct, or the library was built incorrectly.

The more I considered it the less I was able to justify the ability to ignore these errors as an option since it's too implicit and could easily ignore unintended dependencies.  I did add a parameter to tree_libs which can be enabled to ignore these errors, but there's no new command line options yet.

This is what the new error looks like in practice, compared to the example in #90:
```
delocate-wheel -v dist/*.whl
Fixing: dist/tcod-11.19.2.dev2-cp35-abi3-macosx_10_9_x86_64.whl
Traceback (most recent call last):
  File "/Users/runner/work/python-tcod/python-tcod/venv/bin/delocate-wheel", line 8, in <module>
    sys.exit(main())
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/cmd/delocate_wheel.py", line 72, in main
    check_verbose=opts.verbose)
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/delocating.py", line 378, in delocate_wheel
    lib_filt_func, copy_filt_func)
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/delocating.py", line 290, in delocate_path
    return copy_recurse(lib_path, copy_filt_func, copied)
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/delocating.py", line 146, in copy_recurse
    _copy_required(lib_path, copy_filt_func, copied_libs)
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/delocating.py", line 202, in _copy_required
    lib_dict = tree_libs(lib_path)
  File "/Users/runner/work/python-tcod/python-tcod/venv/lib/python3.7/site-packages/delocate/libsana.py", line 103, in tree_libs
    raise DependencyNotFound(error_msg)
delocate.libsana.DependencyNotFound: Could not find these dependencies:
@rpath/hidapi.framework/Versions/A/hidapi not found:
  Needed by: /private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/tmpabvk0pzn/wheel/tcod/.dylibs/SDL2
  Search path:
    @executable_path/Frameworks
    @loader_path/Frameworks
```
This error reveals what happened.  SDL2 now has a Frameworks directory embedded in its own framework and delocate doesn't support `@loader_path` yet.  This will need to be fixed so I can update SDL to the latest version, but I'm not a hurry.  Anyone else might be able to use `DYLD_LIBRARY_PATH` as a workaround.

As mentioned before this could possibly be a breaking change.  I've given my reasons for why this is acceptable but tree_libs can be told to ignore errors if you can pass the option down to it.

Resolves #90 