### PR TITLE
Add Python 2 style type-hinting.  Enforce Flake8 and MyPy linters with GitHub Actions.

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -1,0 +1,23 @@
+name: Python linters
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  flake8:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install Flake8
+      run: |
+        pip install flake8
+    - name: Run Flake8
+      uses: suo/flake8-github-action@releases/v1
+      with:
+        checkName: 'flake8'  # NOTE: this needs to be the same as the job name.
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -21,3 +21,23 @@ jobs:
         checkName: 'flake8'  # NOTE: this needs to be the same as the job name.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  mypy:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install MyPy
+      run: |
+        pip install mypy
+    - name: Install Delocate dependencies.
+      run: |
+        pip install pytest
+        python setup.py develop
+    - uses: kolonialno/mypy-action@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        max-errors: 0
+        paths: delocate

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 2.7
+
+[mypy-wheel.*]
+ignore_missing_imports = True
+
+[mypy-pytest]
+# Skip incompatible sub-modules.
+follow_imports = skip

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -7,3 +7,7 @@ ignore_missing_imports = True
 [mypy-pytest]
 # Skip incompatible sub-modules.
 follow_imports = skip
+
+[mypy-delocate._version]
+# Ignore delocate._version module.
+ignore_errors = True

--- a/delocate/__init__.py
+++ b/delocate/__init__.py
@@ -4,7 +4,7 @@ from .delocating import delocate_path, delocate_wheel, patch_wheel
 from .libsana import tree_libs, wheel_libs
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+__version__ = get_versions()['version']  # type: ignore
 del get_versions
 
 __all__ = ("delocate_path", "delocate_wheel", "patch_wheel", "tree_libs",

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -26,6 +26,7 @@ from delocate.wheeltools import add_platforms, WheelToolsError
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -16,6 +16,7 @@ from delocate.fuse import fuse_wheels
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL1 WHEEL2\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -15,6 +15,7 @@ from delocate.libsana import stripped_lib_dict
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_OR_PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_patch.py
+++ b/delocate/cmd/delocate_patch.py
@@ -16,6 +16,7 @@ from delocate import patch_wheel, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME PATCH_FNAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -12,6 +12,7 @@ from delocate import delocate_path, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function, absolute_import
 import os
 from os.path import join as pjoin, basename, exists, expanduser
 import sys
+from typing import List, Optional, Text
 
 from optparse import OptionParser, Option
 
@@ -16,6 +17,7 @@ from delocate import delocate_wheel, __version__
 
 
 def main():
+    # type: () -> None
     parser = OptionParser(
         usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
         version="%prog " + __version__)
@@ -52,6 +54,7 @@ def main():
             os.makedirs(wheel_dir)
     else:
         wheel_dir = None
+    require_archs = None  # type: Optional[List[Text]]
     if opts.require_archs is None:
         require_archs = [] if opts.check_archs else None
     elif ',' in opts.require_archs:

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -16,6 +16,7 @@ libraries.
 import os
 from os.path import (join as pjoin, exists, splitext, relpath, abspath)
 import shutil
+from typing import Container, Text
 
 from .tools import (zip2dir, dir2zip, cmp_contents, lipo_fuse,
                     open_rw, chmod_perms)
@@ -24,6 +25,7 @@ from .wheeltools import rewrite_record
 
 
 def _copyfile(in_fname, out_fname):
+    # type: (Text, Text) -> None
     # Copies files without read / write permission
     perms = chmod_perms(in_fname)
     with open_rw(in_fname, 'rb') as fobj:
@@ -34,6 +36,7 @@ def _copyfile(in_fname, out_fname):
 
 
 def fuse_trees(to_tree, from_tree, lib_exts=('.so', '.dylib', '.a')):
+    # type: (Text, Text, Container[Text]) -> None
     """ Fuse path `from_tree` into path `to_tree`
 
     For each file in `from_tree` - check for library file extension (in
@@ -78,6 +81,7 @@ def fuse_trees(to_tree, from_tree, lib_exts=('.so', '.dylib', '.a')):
 
 
 def fuse_wheels(to_wheel, from_wheel, out_wheel):
+    # type: (Text, Text, Text) -> None
     """ Fuse `from_wheel` into `to_wheel`, write to `out_wheel`
 
     Parameters

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -7,13 +7,20 @@ import os
 from os.path import basename, join as pjoin, realpath
 
 import warnings
+from typing import Callable, Dict, Iterable, List, Optional, Text
+
+import six
 
 from .tools import (get_install_names, zip2dir, get_rpaths,
                     get_environment_variable_paths)
 from .tmpdirs import TemporaryDirectory
 
 
-def tree_libs(start_path, filt_func=None):
+def tree_libs(
+    start_path,  # type: Text
+    filt_func=None  # type: Optional[Callable[[Text], bool]]
+):
+    # type: (...) -> Dict[Text, Dict[Text, Text]]
     """ Return analysis of library dependencies within `start_path`
 
     Parameters
@@ -49,7 +56,7 @@ def tree_libs(start_path, filt_func=None):
     * https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/dyld.1.html  # noqa: E501
     * http://matthew-brett.github.io/pydagogue/mac_runtime_link.html
     """
-    lib_dict = {}
+    lib_dict = {}  # type: Dict[Text, Dict[Text, Text]]
     env_var_paths = get_environment_variable_paths()
     for dirpath, dirnames, basenames in os.walk(start_path):
         for base in basenames:
@@ -76,6 +83,7 @@ def tree_libs(start_path, filt_func=None):
 
 
 def resolve_rpath(lib_path, rpaths):
+    # type: (Text, Iterable[Text]) -> Text
     """ Return `lib_path` with its `@rpath` resolved
 
     If the `lib_path` doesn't have `@rpath` then it's returned as is.
@@ -115,6 +123,7 @@ def resolve_rpath(lib_path, rpaths):
 
 
 def search_environment_for_lib(lib_path):
+    # type: (Text) -> Text
     """ Search common environment variables for `lib_path`
 
     We'll use a single approach here:
@@ -166,6 +175,7 @@ def search_environment_for_lib(lib_path):
 
 
 def get_prefix_stripper(strip_prefix):
+    # type: (Text) -> Callable[[Text], Text]
     """ Return function to strip `strip_prefix` prefix from string if present
 
     Parameters
@@ -182,11 +192,13 @@ def get_prefix_stripper(strip_prefix):
     n = len(strip_prefix)
 
     def stripper(path):
+        # type: (Text) -> Text
         return path if not path.startswith(strip_prefix) else path[n:]
     return stripper
 
 
 def get_rp_stripper(strip_path):
+    # type: (Text) -> Callable[[Text], Text]
     """ Return function to strip ``realpath`` of `strip_path` from string
 
     Parameters
@@ -205,6 +217,7 @@ def get_rp_stripper(strip_path):
 
 
 def stripped_lib_dict(lib_dict, strip_prefix):
+    # type: (Dict[Text, Dict[Text, Text]], Text) -> Dict[Text, Dict[Text, Text]]
     """ Return `lib_dict` with `strip_prefix` removed from start of paths
 
     Use to give form of `lib_dict` that appears relative to some base path
@@ -237,7 +250,11 @@ def stripped_lib_dict(lib_dict, strip_prefix):
     return relative_dict
 
 
-def wheel_libs(wheel_fname, filt_func=None):
+def wheel_libs(
+    wheel_fname,  # type: Text
+    filt_func=None  # type: Optional[Callable[[Text], bool]]
+):
+    # type: (...) -> Dict[Text, Dict[Text, Text]]
     """ Return analysis of library dependencies with a Python wheel
 
     Use this routine for a dump of the dependency tree.
@@ -268,7 +285,8 @@ def wheel_libs(wheel_fname, filt_func=None):
 
 
 def _paths_from_var(varname, lib_basename):
-    var = os.environ.get(varname)
+    # type: (Text, Text) -> List[Text]
+    var = os.environ.get(six.ensure_str(varname))
     if var is None:
         return []
     return [pjoin(path, lib_basename) for path in var.split(':')]

--- a/delocate/tests/env_tools.py
+++ b/delocate/tests/env_tools.py
@@ -1,19 +1,24 @@
 from contextlib import contextmanager
 import os
+from typing import Iterator, Text
+
+import six
 
 from ..tmpdirs import InTemporaryDirectory
 
 
 @contextmanager
 def TempDirWithoutEnvVars(*env_vars):
+    # type: (*Text) -> Iterator[Text]
     """ Remove `env_vars` from the environment and restore them after
     testing is complete.
     """
     old_vars = {}
     for var in env_vars:
-        old_vars[var] = os.environ.get(var, None)
-        if old_vars[var] is not None:
-            del os.environ[var]
+        try:
+            old_vars[six.ensure_str(var)] = os.environ[six.ensure_str(var)]
+        except KeyError:
+            pass
     try:
         with InTemporaryDirectory() as tmpdir:
             yield tmpdir

--- a/delocate/tests/pytest_tools.py
+++ b/delocate/tests/pytest_tools.py
@@ -1,26 +1,33 @@
+from typing import Any
+
 import pytest
 
 
 def assert_true(condition):
+    # type: (Any) -> None
     __tracebackhide__ = True
     assert condition
 
 
 def assert_false(condition):
+    # type: (Any) -> None
     __tracebackhide__ = True
     assert not condition
 
 
 def assert_raises(expected_exception, *args, **kwargs):
+    # type: (Any, *Any, **Any) -> Any
     __tracebackhide__ = True
     return pytest.raises(expected_exception, *args, **kwargs)
 
 
 def assert_equal(first, second):
+    # type: (Any, Any) -> None
     __tracebackhide__ = True
     assert first == second
 
 
 def assert_not_equal(first, second):
+    # type: (Any, Any) -> None
     __tracebackhide__ = True
     assert first != second

--- a/delocate/tests/test_fuse.py
+++ b/delocate/tests/test_fuse.py
@@ -5,8 +5,9 @@ import os
 import sys
 from os.path import (join as pjoin, relpath, isdir, dirname, basename)
 import shutil
+from typing import Iterable, Text
 
-from ..tools import (cmp_contents, get_archs, zip2dir, dir2zip, back_tick,
+from ..tools import (cmp_contents, get_archs, zip2dir, dir2zip, check_call,
                      open_readable)
 from ..fuse import fuse_trees, fuse_wheels
 from ..tmpdirs import InTemporaryDirectory
@@ -20,6 +21,7 @@ from .test_wheeltools import assert_record_equal
 
 
 def assert_same_tree(tree1, tree2):
+    # type: (Text, Text) -> None
     for dirpath, dirnames, filenames in os.walk(tree1):
         tree2_dirpath = pjoin(tree2, relpath(dirpath, tree1))
         for dname in dirnames:
@@ -37,10 +39,12 @@ def assert_same_tree(tree1, tree2):
 
 
 def assert_listdir_equal(path, listing):
+    # type: (Text, Iterable[Text]) -> None
     assert sorted(os.listdir(path)) == sorted(listing)
 
 
 def test_fuse_trees():
+    # type: () -> None
     # Test function to fuse two paths
     with InTemporaryDirectory():
         os.mkdir('tree1')
@@ -86,6 +90,7 @@ def test_fuse_trees():
 
 
 def test_fuse_wheels():
+    # type: () -> None
     # Test function to fuse two wheels
     wheel_base = basename(PURE_WHEEL)
     with InTemporaryDirectory():
@@ -97,7 +102,7 @@ def test_fuse_wheels():
         zip2dir(wheel_base, 'fused_wheel')
         assert_same_tree('to_wheel', 'fused_wheel')
         # Check unpacking works on fused wheel
-        back_tick([sys.executable, '-m', 'wheel', 'unpack', wheel_base])
+        check_call([sys.executable, '-m', 'wheel', 'unpack', wheel_base])
         # Put lib into wheel
         shutil.copyfile(LIB64A, pjoin('from_wheel', 'fakepkg2', 'liba.a'))
         rewrite_record('from_wheel')

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -4,6 +4,7 @@ import os
 from os.path import (join as pjoin, exists, dirname, basename)
 
 import shutil
+from typing import Iterable, List, Text
 
 from ..tools import (InstallNameError, get_install_names, set_install_name,
                      get_install_id, get_rpaths, add_rpath, parse_install_name,
@@ -15,23 +16,24 @@ from .pytest_tools import (assert_raises, assert_equal)
 from .env_tools import TempDirWithoutEnvVars
 
 # External libs linked from test data
-LIBSTDCXX = '/usr/lib/libstdc++.6.dylib'
-LIBSYSTEMB = '/usr/lib/libSystem.B.dylib'
+LIBSTDCXX = u'/usr/lib/libstdc++.6.dylib'
+LIBSYSTEMB = u'/usr/lib/libSystem.B.dylib'
 EXT_LIBS = (LIBSTDCXX, LIBSYSTEMB)
 
-DATA_PATH = pjoin(dirname(__file__), 'data')
-LIBA = pjoin(DATA_PATH, 'liba.dylib')
-LIBB = pjoin(DATA_PATH, 'libb.dylib')
-LIBC = pjoin(DATA_PATH, 'libc.dylib')
-LIBA_STATIC = pjoin(DATA_PATH, 'liba.a')
-A_OBJECT = pjoin(DATA_PATH, 'a.o')
-TEST_LIB = pjoin(DATA_PATH, 'test-lib')
-ICO_FILE = pjoin(DATA_PATH, 'icon.ico')
-PY_FILE = pjoin(DATA_PATH, 'some_code.py')
-BIN_FILE = pjoin(DATA_PATH, 'binary_example.bin')
+DATA_PATH = pjoin(dirname(__file__), u'data')
+LIBA = pjoin(DATA_PATH, u'liba.dylib')
+LIBB = pjoin(DATA_PATH, u'libb.dylib')
+LIBC = pjoin(DATA_PATH, u'libc.dylib')
+LIBA_STATIC = pjoin(DATA_PATH, u'liba.a')
+A_OBJECT = pjoin(DATA_PATH, u'a.o')
+TEST_LIB = pjoin(DATA_PATH, u'test-lib')
+ICO_FILE = pjoin(DATA_PATH, u'icon.ico')
+PY_FILE = pjoin(DATA_PATH, u'some_code.py')
+BIN_FILE = pjoin(DATA_PATH, u'binary_example.bin')
 
 
 def test_get_install_names():
+    # type: () -> None
     # Test install name listing
     assert_equal(set(get_install_names(LIBA)),
                  set(EXT_LIBS))
@@ -63,6 +65,7 @@ def test_get_install_names():
 
 
 def test_parse_install_name():
+    # type: () -> None
     assert_equal(parse_install_name(
         "liba.dylib (compatibility version 0.0.0, current version 0.0.0)"),
         ("liba.dylib", "0.0.0", "0.0.0"))
@@ -77,6 +80,7 @@ def test_parse_install_name():
 
 
 def test_install_id():
+    # type: () -> None
     # Test basic otool library listing
     assert_equal(get_install_id(LIBA), 'liba.dylib')
     assert_equal(get_install_id(LIBB), 'libb.dylib')
@@ -88,6 +92,7 @@ def test_install_id():
 
 
 def test_change_install_name():
+    # type: () -> None
     # Test ability to change install names in library
     libb_names = get_install_names(LIBB)
     with InTemporaryDirectory() as tmpdir:
@@ -103,6 +108,7 @@ def test_change_install_name():
 
 
 def test_set_install_id():
+    # type: () -> None
     # Test ability to change install id in library
     liba_id = get_install_id(LIBA)
     with InTemporaryDirectory() as tmpdir:
@@ -116,6 +122,7 @@ def test_set_install_id():
 
 
 def test_get_rpaths():
+    # type: () -> None
     # Test fetch of rpaths
     # Not dynamic libs, no rpaths
     for fname in (LIBB, A_OBJECT, LIBA_STATIC, ICO_FILE, PY_FILE, BIN_FILE):
@@ -123,6 +130,7 @@ def test_get_rpaths():
 
 
 def test_get_environment_variable_paths():
+    # type: () -> None
     # Test that environment variable paths are fetched in a specific order
     with TempDirWithoutEnvVars('DYLD_FALLBACK_LIBRARY_PATH',
                                'DYLD_LIBRARY_PATH'):
@@ -132,6 +140,7 @@ def test_get_environment_variable_paths():
 
 
 def test_add_rpath():
+    # type: () -> None
     # Test adding to rpath
     with InTemporaryDirectory() as tmpdir:
         libfoo = pjoin(tmpdir, 'libfoo.dylib')
@@ -144,6 +153,7 @@ def test_add_rpath():
 
 
 def _copy_libs(lib_files, out_path):
+    # type: (Iterable[Text], Text) -> List[Text]
     copied = []
     if not exists(out_path):
         os.makedirs(out_path)

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -5,6 +5,7 @@ Utilities for analyzing library dependencies in trees and wheels
 
 import os
 from os.path import (join as pjoin, dirname, realpath, relpath, split)
+from typing import Dict, Iterable, Text
 
 from ..libsana import (tree_libs, get_prefix_stripper, get_rp_stripper,
                        stripped_lib_dict, wheel_libs, resolve_rpath)
@@ -21,6 +22,7 @@ from .test_wheelies import (PLAT_WHEEL, PURE_WHEEL, STRAY_LIB_DEP)
 
 
 def get_ext_dict(local_libs):
+    # type: (Iterable[Text]) -> Dict[Text, Dict[Text, Text]]
     ext_deps = {}
     for ext_lib in EXT_LIBS:
         lib_deps = {}
@@ -31,6 +33,7 @@ def get_ext_dict(local_libs):
 
 
 def test_tree_libs():
+    # type: () -> None
     # Test ability to walk through tree, finding dynamic libary refs
     # Copy specific files to avoid working tree cruft
     to_copy = [LIBA, LIBB, LIBC, TEST_LIB]
@@ -48,6 +51,7 @@ def test_tree_libs():
         assert_equal(tree_libs(tmpdir), exp_dict)
 
         def filt(fname):
+            # type: (Text) -> bool
             return fname.endswith('.dylib')
         exp_dict = get_ext_dict([liba, libb, libc])
         exp_dict.update({
@@ -95,6 +99,7 @@ def test_tree_libs():
 
 
 def test_get_prefix_stripper():
+    # type: () -> None
     # Test function factory to strip prefixes
     f = get_prefix_stripper('')
     assert_equal(f('a string'), 'a string')
@@ -105,6 +110,7 @@ def test_get_prefix_stripper():
 
 
 def test_get_rp_stripper():
+    # type: () -> None
     # realpath prefix stripper
     # Just does realpath and adds path sep
     cwd = realpath(os.getcwd())
@@ -118,6 +124,7 @@ def test_get_rp_stripper():
 
 
 def get_ext_dict_stripped(local_libs, start_path):
+    # type: (Iterable[Text], Text) -> Dict[Text, Dict[Text, Text]]
     ext_dict = {}
     for ext_lib in EXT_LIBS:
         lib_deps = {}
@@ -131,6 +138,7 @@ def get_ext_dict_stripped(local_libs, start_path):
 
 
 def test_stripped_lib_dict():
+    # type: () -> None
     # Test routine to return lib_dict with relative paths
     to_copy = [LIBA, LIBB, LIBC, TEST_LIB]
     with InTemporaryDirectory() as tmpdir:
@@ -164,6 +172,7 @@ def test_stripped_lib_dict():
 
 
 def test_wheel_libs():
+    # type: () -> None
     # Test routine to list dependencies from wheels
     assert_equal(wheel_libs(PURE_WHEEL), {})
     mod2 = pjoin('fakepkg1', 'subpkg', 'module2.so')
@@ -172,11 +181,13 @@ def test_wheel_libs():
                   realpath(LIBSYSTEMB): {mod2: LIBSYSTEMB}})
 
     def filt(fname):
+        # type: (Text) -> bool
         return not fname.endswith(mod2)
     assert_equal(wheel_libs(PLAT_WHEEL, filt), {})
 
 
 def test_resolve_rpath():
+    # type: () -> None
     # A minimal test of the resolve_rpath function
     path, lib = split(LIBA)
     lib_rpath = pjoin('@rpath', lib)

--- a/delocate/tests/test_tmpdirs.py
+++ b/delocate/tests/test_tmpdirs.py
@@ -13,6 +13,7 @@ MY_DIR = dirname(MY_PATH)
 
 
 def test_given_directory():
+    # type: () -> None
     # Test InGivenDirectory
     cwd = getcwd()
     with InGivenDirectory() as tmpdir:

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -106,6 +106,7 @@ def test_ensure_writable():
         # Set to user rw, else r
         os.chmod('test.bin', 0o644)
         st = os.stat('test.bin')
+
         @ensure_writable
         def foo(fname):
             pass
@@ -120,15 +121,17 @@ def test_ensure_writable():
 
 def test_parse_install_name():
     # otool on versions previous to Catalina
-    line0 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
-            '(compatibility version 1.2.0, current version 1.11.0)')
+    line0 = (
+        '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+        '(compatibility version 1.2.0, current version 1.11.0)')
     name, cpver, cuver = (
         '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore',
         '1.2.0', '1.11.0')
     assert parse_install_name(line0) == (name, cpver, cuver)
     # otool on Catalina
-    line1 = ('/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
-             '(compatibility version 1.2.0, current version 1.11.0, weak)')
+    line1 = (
+        '/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore '
+        '(compatibility version 1.2.0, current version 1.11.0, weak)')
     assert parse_install_name(line1) == (name, cpver, cuver)
 
 

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -7,7 +7,7 @@ import stat
 import shutil
 from typing import Iterator, Text
 
-from ..tools import (unique_by_index, ensure_writable, chmod_perms,
+from ..tools import (back_tick, unique_by_index, ensure_writable, chmod_perms,
                      ensure_permissions, parse_install_name, zip2dir, dir2zip,
                      find_package_dirs, cmp_contents, get_archs, lipo_fuse,
                      replace_signature, validate_signature, add_rpath,
@@ -35,6 +35,16 @@ def test_call():
     assert_equal(run_call(cmd), (0, "Hello", ""))
     cmd = 'python -c "raise ValueError()"'
     assert_raises(RuntimeError, check_call, cmd)
+
+
+def test_back_tick():
+    # type: () -> None
+    cmd = 'python -c "print(\'Hello\')"'
+    assert_equal(back_tick(cmd), "Hello")
+    assert_equal(back_tick(cmd, ret_err=True), ("Hello", ""))
+    assert_equal(back_tick(cmd, True, False), (b"Hello", b""))
+    cmd = 'python -c "raise ValueError()"'
+    assert_raises(RuntimeError, back_tick, cmd)
 
 
 def test_uniqe_by_index():

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -66,21 +66,21 @@ def test_in_wheel():
     # Test in-wheel context managers
     # Stuff they share
     for ctx_mgr in InWheel, InWheelCtx:
-        with ctx_mgr(PURE_WHEEL):  # type: ignore  # No output wheel
+        with ctx_mgr(PURE_WHEEL):  # No output wheel
             shutil.rmtree('fakepkg2')
             res = sorted(os.listdir('.'))
         assert_equal(res, ['fakepkg2-1.0.dist-info'])
         # The original wheel unchanged
-        with ctx_mgr(PURE_WHEEL):  # type: ignore  # No output wheel
+        with ctx_mgr(PURE_WHEEL):  # No output wheel
             res = sorted(os.listdir('.'))
         assert_equal(res, ['fakepkg2', 'fakepkg2-1.0.dist-info'])
         # Make an output wheel file in a temporary directory
         with InTemporaryDirectory():
             mod_path = pjoin('fakepkg2', 'module1.py')
-            with ctx_mgr(PURE_WHEEL, 'mungled.whl'):  # type: ignore
+            with ctx_mgr(PURE_WHEEL, 'mungled.whl'):
                 assert_true(isfile(mod_path))
                 os.unlink(mod_path)
-            with ctx_mgr('mungled.whl'):  # type: ignore
+            with ctx_mgr('mungled.whl'):
                 assert_false(isfile(mod_path))
     # Different return from context manager
     with InWheel(PURE_WHEEL) as wheel_path:

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -4,7 +4,8 @@
 import os
 from os.path import join as pjoin, exists, isfile, basename, realpath, splitext
 import shutil
-from typing import Any, Iterable, List, Sequence, Text, Tuple, TypeVar
+from typing import (Any, Iterable, List, Sequence, Text, Tuple, Type, TypeVar,
+                    Union)
 
 try:
     from wheel.install import WheelFile
@@ -65,7 +66,10 @@ def test_in_wheel():
     # type: () -> None
     # Test in-wheel context managers
     # Stuff they share
-    for ctx_mgr in InWheel, InWheelCtx:
+    wheel_classes = (
+        InWheel, InWheelCtx
+    )  # type: Tuple[Union[Type[InWheel], Type[InWheelCtx]], ...]
+    for ctx_mgr in wheel_classes:
         with ctx_mgr(PURE_WHEEL):  # No output wheel
             shutil.rmtree('fakepkg2')
             res = sorted(os.listdir('.'))

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -4,6 +4,7 @@
 import os
 from os.path import join as pjoin, exists, isfile, basename, realpath, splitext
 import shutil
+from typing import Any, Iterable, List, Sequence, Text, Tuple, TypeVar
 
 try:
     from wheel.install import WheelFile
@@ -21,12 +22,18 @@ from .pytest_tools import (assert_true, assert_false, assert_raises,
 from .test_wheelies import PURE_WHEEL, PLAT_WHEEL
 
 
+KT = TypeVar("KT")
+VT = TypeVar("VT")
+
+
 def assert_record_equal(record_orig, record_new):
+    # type: (Text, Text) -> None
     assert_equal(sorted(record_orig.splitlines()),
                  sorted(record_new.splitlines()))
 
 
 def test_rewrite_record():
+    # type: () -> None
     dist_info_sdir = 'fakepkg2-1.0.dist-info'
     with InTemporaryDirectory():
         zip2dir(PURE_WHEEL, 'wheel')
@@ -55,24 +62,25 @@ def test_rewrite_record():
 
 
 def test_in_wheel():
+    # type: () -> None
     # Test in-wheel context managers
     # Stuff they share
     for ctx_mgr in InWheel, InWheelCtx:
-        with ctx_mgr(PURE_WHEEL):  # No output wheel
+        with ctx_mgr(PURE_WHEEL):  # type: ignore  # No output wheel
             shutil.rmtree('fakepkg2')
             res = sorted(os.listdir('.'))
         assert_equal(res, ['fakepkg2-1.0.dist-info'])
         # The original wheel unchanged
-        with ctx_mgr(PURE_WHEEL):  # No output wheel
+        with ctx_mgr(PURE_WHEEL):  # type: ignore  # No output wheel
             res = sorted(os.listdir('.'))
         assert_equal(res, ['fakepkg2', 'fakepkg2-1.0.dist-info'])
         # Make an output wheel file in a temporary directory
         with InTemporaryDirectory():
             mod_path = pjoin('fakepkg2', 'module1.py')
-            with ctx_mgr(PURE_WHEEL, 'mungled.whl'):
+            with ctx_mgr(PURE_WHEEL, 'mungled.whl'):  # type: ignore
                 assert_true(isfile(mod_path))
                 os.unlink(mod_path)
-            with ctx_mgr('mungled.whl'):
+            with ctx_mgr('mungled.whl'):  # type: ignore
                 assert_false(isfile(mod_path))
     # Different return from context manager
     with InWheel(PURE_WHEEL) as wheel_path:
@@ -92,10 +100,12 @@ def test_in_wheel():
 
 
 def _filter_key(items, key):
+    # type: (Iterable[Tuple[KT, VT]], KT) -> List[Tuple[KT, VT]]
     return [(k, v) for k, v in items if k != key]
 
 
 def get_info(wheelfile):
+    # type: (WheelFile) -> Any
     # Work round wheel API changes
     try:
         return wheelfile.parsed_wheel_info
@@ -108,6 +118,7 @@ def get_info(wheelfile):
 
 
 def assert_winfo_similar(whl_fname, exp_items, drop_version=True):
+    # type: (Text, Sequence[Tuple[Text, Text]], bool) -> None
     wf = WheelFile(whl_fname)
     wheel_parts = wf.parsed_filename.groupdict()
     # Info can contain duplicate keys (e.g. Tag)
@@ -125,6 +136,7 @@ def assert_winfo_similar(whl_fname, exp_items, drop_version=True):
 
 
 def test_add_platforms():
+    # type: () -> None
     # Check adding platform to wheel name and tag section
     exp_items = [('Generator', 'bdist_wheel {pip_version}'),
                  ('Root-Is-Purelib', 'false'),
@@ -141,7 +153,7 @@ def test_add_platforms():
         assert_false(exists(out_fname))
         out_fname = (splitext(basename(PLAT_WHEEL))[0] +
                      '.macosx_10_9_intel.macosx_10_9_x86_64.whl')
-        assert_equal(realpath(add_platforms(PLAT_WHEEL, plats, tmpdir)),
+        assert_equal(realpath(add_platforms(PLAT_WHEEL, plats, tmpdir) or ""),
                      realpath(out_fname))
         assert_true(isfile(out_fname))
         # Expected output minus wheel-version (that might change)
@@ -159,12 +171,14 @@ def test_add_platforms():
         # Assemble platform tags in two waves to check tags are not being
         # multiplied
         out_1 = splitext(basename(PLAT_WHEEL))[0] + '.macosx_10_9_intel.whl'
-        assert_equal(realpath(add_platforms(PLAT_WHEEL, plats[0:1], tmpdir)),
-                     realpath(out_1))
+        assert_equal(
+            realpath(add_platforms(PLAT_WHEEL, plats[0:1], tmpdir) or ""),
+            realpath(out_1))
         assert_winfo_similar(out_1, extra_exp[:-1])
         out_2 = splitext(out_1)[0] + '.macosx_10_9_x86_64.whl'
-        assert_equal(realpath(add_platforms(out_1, plats[1:], tmpdir, True)),
-                     realpath(out_2))
+        assert_equal(
+            realpath(add_platforms(out_1, plats[1:], tmpdir, True) or ""),
+            realpath(out_2))
         assert_winfo_similar(out_2, extra_exp)
         # Default is to write into directory of wheel
         os.mkdir('wheels')

--- a/delocate/tmpdirs.py
+++ b/delocate/tmpdirs.py
@@ -13,6 +13,8 @@ from __future__ import division, print_function, absolute_import
 import os
 import shutil
 from tempfile import template, mkdtemp
+from typing import Any, Optional, Text
+from typing_extensions import Literal
 
 
 class TemporaryDirectory(object):
@@ -33,18 +35,22 @@ class TemporaryDirectory(object):
     False
     """
     def __init__(self, suffix="", prefix=template, dir=None):
+        # type: (Text, Text, Optional[Text]) -> None
         self.name = mkdtemp(suffix, prefix, dir)
         self._closed = False
 
     def __enter__(self):
+        # type: () -> Text
         return self.name
 
     def cleanup(self):
+        # type: () -> None
         if not self._closed:
             shutil.rmtree(self.name)
             self._closed = True
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
         self.cleanup()
         return False
 
@@ -66,11 +72,13 @@ class InTemporaryDirectory(TemporaryDirectory):
     True
     '''
     def __enter__(self):
+        # type: () -> Text
         self._pwd = os.getcwd()
         os.chdir(self.name)
         return super(InTemporaryDirectory, self).__enter__()
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> Literal[False]
         os.chdir(self._pwd)
         return super(InTemporaryDirectory, self).__exit__(exc, value, tb)
 
@@ -99,6 +107,7 @@ class InGivenDirectory(object):
     again.
     """
     def __init__(self, path=None):
+        # type: (Optional[Text]) -> None
         """ Initialize directory context manager
 
         Parameters
@@ -112,6 +121,7 @@ class InGivenDirectory(object):
         self.path = os.path.abspath(path)
 
     def __enter__(self):
+        # type: () -> Text
         self._pwd = os.path.abspath(os.getcwd())
         if not os.path.isdir(self.path):
             os.mkdir(self.path)
@@ -119,4 +129,5 @@ class InGivenDirectory(object):
         return self.path
 
     def __exit__(self, exc, value, tb):
+        # type: (Any, Any, Any) -> None
         os.chdir(self._pwd)

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -333,8 +333,8 @@ def get_environment_variable_paths():
     """ Return a tuple of entries in `DYLD_LIBRARY_PATH` and
     `DYLD_FALLBACK_LIBRARY_PATH`.
 
-    This will allow us to search those locations for dependencies of libraries as
-    well as `@rpath` entries.
+    This will allow us to search those locations for dependencies of libraries
+    as well as `@rpath` entries.
 
     Returns
     -------
@@ -494,8 +494,10 @@ def get_archs(libname):
         assert len(lines) == 1
         line = lines[0]
     for reggie in (
-            'Non-fat file: {0} is architecture: (.*)'.format(re.escape(libname)),
-            'Architectures in the fat file: {0} are: (.*)'.format(re.escape(libname))):
+        'Non-fat file: {0} is architecture: (.*)'.format(re.escape(libname)),
+        'Architectures in the fat file: {0} are: (.*)'.format(
+                                                            re.escape(libname))
+    ):
         reggie = re.compile(reggie)
         match = reggie.match(line)
         if match is not None:

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -8,14 +8,66 @@ import zipfile
 import re
 import stat
 import time
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    FrozenSet,
+    Text,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+
+T = TypeVar("T")
+F = TypeVar('F', bound=Callable[..., Any])
 
 
 class InstallNameError(Exception):
     pass
 
 
-def back_tick(cmd, ret_err=False, as_str=True, raise_err=None):
-    """ Run command `cmd`, return stdout, or stdout, stderr if `ret_err`
+def run_call(cmd):
+    # type: (Union[Text, Sequence[Text]]) -> Tuple[int, Text, Text]
+    """ Run a command and return the exit code as well as stdout and stderr.
+
+    If unsure, then use the `check_call` function instead.
+
+    Parameters
+    ----------
+    cmd : sequence
+        command to execute
+
+    Returns
+    -------
+    returncode : int
+        The return code the call exited with.
+    stdout : str
+        The stripped output from the calls stdout pipe.
+    stderr : str
+        The stripped output from the calls stderr pipe.
+    """
+    cmd_is_seq = not isinstance(cmd, str)
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=not cmd_is_seq,
+                 universal_newlines=True)
+    out = ""
+    err = ""
+    while proc.returncode is None:
+        out_, err_ = proc.communicate()
+        out += out_
+        err += err_
+    return proc.returncode, out.strip(), err.strip()
+
+
+def check_call(cmd):
+    # type: (Union[Text, Sequence[Text]]) -> Text
+    """ Run a command and return the output on success or raise an exception on
+    an error.
 
     Roughly equivalent to ``check_output`` in Python 2.7
 
@@ -23,53 +75,31 @@ def back_tick(cmd, ret_err=False, as_str=True, raise_err=None):
     ----------
     cmd : sequence
         command to execute
-    ret_err : bool, optional
-        If True, return stderr in addition to stdout.  If False, just return
-        stdout
-    as_str : bool, optional
-        Whether to decode outputs to unicode string on exit.
-    raise_err : None or bool, optional
-        If True, raise RuntimeError for non-zero return code. If None, set to
-        True when `ret_err` is False, False if `ret_err` is True
 
     Returns
     -------
-    out : str or tuple
-        If `ret_err` is False, return stripped string containing stdout from
-        `cmd`.  If `ret_err` is True, return tuple of (stdout, stderr) where
-        ``stdout`` is the stripped stdout, and ``stderr`` is the stripped
-        stderr.
+    stdout : str
+        The stripped output from the calls stdout pipe.
 
     Raises
     ------
-    Raises RuntimeError if command returns non-zero exit code and `raise_err`
-    is True
+    RuntimeError
+        If the call returns a non-zero exit code.
     """
-    if raise_err is None:
-        raise_err = False if ret_err else True
-    cmd_is_seq = isinstance(cmd, (list, tuple))
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, shell=not cmd_is_seq)
-    out, err = proc.communicate()
-    retcode = proc.returncode
-    cmd_str = ' '.join(cmd) if cmd_is_seq else cmd
-    if retcode is None:
-        proc.terminate()
-        raise RuntimeError(cmd_str + ' process did not terminate')
-    if raise_err and retcode != 0:
-        raise RuntimeError('{0} returned code {1} with error {2}'.format(
-                           cmd_str, retcode, err.decode('latin-1')))
-    out = out.strip()
-    if as_str:
-        out = out.decode('latin-1')
-    if not ret_err:
-        return out
-    err = err.strip()
-    if as_str:
-        err = err.decode('latin-1')
-    return out, err
+    returncode, out, err = run_call(cmd)
+    if returncode != 0:
+        cmd_is_seq = not isinstance(cmd, str)
+        cmd_str = ' '.join(cmd) if cmd_is_seq else cmd
+        raise RuntimeError(
+            '{0} returned code {1} with error {2}'.format(
+                cmd_str, returncode, err
+            )
+        )
+    return out
 
 
 def unique_by_index(sequence):
+    # type: (Iterable[T]) -> List[T]
     """ unique elements in `sequence` in the order in which they occur
 
     Parameters
@@ -90,11 +120,13 @@ def unique_by_index(sequence):
 
 
 def chmod_perms(fname):
+    # type: (Text) -> int
     # Permissions relevant to chmod
     return stat.S_IMODE(os.stat(fname).st_mode)
 
 
 def ensure_permissions(mode_flags=stat.S_IWUSR):
+    # type: (int) -> Callable[[F], F]
     """decorator to ensure a filename has given permissions.
 
     If changed, original permissions are restored after the decorated
@@ -102,7 +134,9 @@ def ensure_permissions(mode_flags=stat.S_IWUSR):
     """
 
     def decorator(f):
+        # type: (F) -> F
         def modify(filename, *args, **kwargs):
+            # type: (str, *Any, **Any) -> Any
             m = chmod_perms(filename) if exists(filename) else mode_flags
             if not m & mode_flags:
                 os.chmod(filename, m | mode_flags)
@@ -112,7 +146,7 @@ def ensure_permissions(mode_flags=stat.S_IWUSR):
                 # restore original permissions
                 if not m & mode_flags:
                     os.chmod(filename, m)
-        return modify
+        return modify  # type: ignore  # Cast to F
 
     return decorator
 
@@ -132,6 +166,7 @@ IN_RE = re.compile(r"(.*) \(compatibility version (\d+\.\d+\.\d+), "
 
 
 def parse_install_name(line):
+    # type: (Text) -> Tuple[Text, Text, Text]
     """ Parse a line of install name output
 
     Parameters
@@ -149,7 +184,11 @@ def parse_install_name(line):
         current version
     """
     line = line.strip()
-    return IN_RE.match(line).groups()
+    match = IN_RE.match(line)
+    if not match:
+        raise RuntimeError("Could not parse {0!r}.".format(line))
+    libname, compat_version, current_version = match.groups()
+    return libname, compat_version, current_version
 
 
 # otool -L strings indicating this is not an object file. The string changes
@@ -170,17 +209,19 @@ BAD_OBJECT_TESTS = [
     lambda s: 'object is not a Mach-O file type' in s,
     # File may not have read permissions
     lambda s: RE_PERM_DEN.search(s) is not None
-]
+]  # type: List[Callable[[Text], bool]]
 
 
 def _cmd_out_err(cmd):
+    # type: (Union[Text, Sequence[Text]]) -> List[Text]
     # Run command, return stdout or stderr if stdout is empty
-    out, err = back_tick(cmd, ret_err=True)
+    _, out, err = run_call(cmd)
     out = err if not len(out) else out
     return out.split('\n')
 
 
 def _line0_says_object(line0, filename):
+    # type: (Text, Text) -> bool
     line0 = line0.strip()
     for test in BAD_OBJECT_TESTS:
         if test(line0):
@@ -198,6 +239,7 @@ def _line0_says_object(line0, filename):
 
 
 def get_install_names(filename):
+    # type: (Text) -> Tuple[Text, ...]
     """ Return install names from library named in `filename`
 
     Returns tuple of install names
@@ -226,6 +268,7 @@ def get_install_names(filename):
 
 
 def get_install_id(filename):
+    # type: (Text) -> Optional[Text]
     """ Return install id from library named in `filename`
 
     Returns None if no install id, or if this is not an object file.
@@ -252,6 +295,7 @@ def get_install_id(filename):
 
 @ensure_writable
 def set_install_name(filename, oldname, newname):
+    # type: (Text, Text, Text) -> None
     """ Set install name `oldname` to `newname` in library filename
 
     Parameters
@@ -267,11 +311,12 @@ def set_install_name(filename, oldname, newname):
     if oldname not in names:
         raise InstallNameError('{0} not in install names for {1}'.format(
             oldname, filename))
-    back_tick(['install_name_tool', '-change', oldname, newname, filename])
+    check_call(['install_name_tool', '-change', oldname, newname, filename])
 
 
 @ensure_writable
 def set_install_id(filename, install_id):
+    # type: (Text, Text) -> None
     """ Set install id for library named in `filename`
 
     Parameters
@@ -287,13 +332,14 @@ def set_install_id(filename, install_id):
     """
     if get_install_id(filename) is None:
         raise InstallNameError('{0} has no install id'.format(filename))
-    back_tick(['install_name_tool', '-id', install_id, filename])
+    check_call(['install_name_tool', '-id', install_id, filename])
 
 
 RPATH_RE = re.compile(r"path (.*) \(offset \d+\)")
 
 
 def get_rpaths(filename):
+    # type: (Text) -> Tuple[Text, ...]
     """ Return a tuple of rpaths from the library `filename`.
 
     If `filename` is not a library then the returned tuple will be empty.
@@ -324,12 +370,15 @@ def get_rpaths(filename):
             continue
         cmdsize, path = lines[line_no:line_no+2]
         assert cmdsize.startswith('cmdsize ')
-        paths.append(RPATH_RE.match(path).groups()[0])
+        match = RPATH_RE.match(path)
+        assert match
+        paths.append(match.groups()[0])
         line_no += 2
     return tuple(paths)
 
 
 def get_environment_variable_paths():
+    # type: () -> Tuple[Text, ...]
     """ Return a tuple of entries in `DYLD_LIBRARY_PATH` and
     `DYLD_FALLBACK_LIBRARY_PATH`.
 
@@ -355,6 +404,7 @@ def get_environment_variable_paths():
 
 @ensure_writable
 def add_rpath(filename, newpath):
+    # type: (Text, Text) -> None
     """ Add rpath `newpath` to library `filename`
 
     Parameters
@@ -364,10 +414,11 @@ def add_rpath(filename, newpath):
     newpath : str
         rpath to add
     """
-    back_tick(['install_name_tool', '-add_rpath', newpath, filename])
+    check_call(['install_name_tool', '-add_rpath', newpath, filename])
 
 
 def zip2dir(zip_fname, out_dir):
+    # type: (Text, Text) -> None
     """ Extract `zip_fname` into output directory `out_dir`
 
     Parameters
@@ -379,10 +430,11 @@ def zip2dir(zip_fname, out_dir):
     """
     # Use unzip command rather than zipfile module to preserve permissions
     # http://bugs.python.org/issue15795
-    back_tick(['unzip', '-o', '-d', out_dir, zip_fname])
+    check_call(['unzip', '-o', '-d', out_dir, zip_fname])
 
 
 def dir2zip(in_dir, zip_fname):
+    # type: (Text, Text) -> None
     """ Make a zip file `zip_fname` with contents of directory `in_dir`
 
     The recorded filenames are relative to `in_dir`, so doing a standard zip
@@ -410,7 +462,7 @@ def dir2zip(in_dir, zip_fname):
                 # PyPI won't accept wheels with windows path separators
                 info.filename = relpath(in_fname, in_dir).replace('\\', '/')
             # Set time from modification time
-            info.date_time = time.localtime(in_stat.st_mtime)
+            info.date_time = time.localtime(in_stat.st_mtime)  # type: ignore
             # See https://stackoverflow.com/questions/434641/how-do-i-set-permissions-attributes-on-a-file-in-a-zip-file-using-pythons-zip/48435482#48435482 # noqa: E501
             # Also set regular file permissions
             perms = stat.S_IMODE(in_stat.st_mode) | stat.S_IFREG
@@ -422,6 +474,7 @@ def dir2zip(in_dir, zip_fname):
 
 
 def find_package_dirs(root_path):
+    # type: (Text) -> Set[Text]
     """ Find python package directories in directory `root_path`
 
     Parameters
@@ -444,6 +497,7 @@ def find_package_dirs(root_path):
 
 
 def cmp_contents(filename1, filename2):
+    # type: (Text, Text) -> bool
     """ Returns True if contents of the files are the same
 
     Parameters
@@ -467,6 +521,7 @@ def cmp_contents(filename1, filename2):
 
 
 def get_archs(libname):
+    # type: (Text) -> FrozenSet[Text]
     """ Return architecture types from library `libname`
 
     Parameters
@@ -483,7 +538,7 @@ def get_archs(libname):
     if not exists(libname):
         raise RuntimeError(libname + " is not a file")
     try:
-        stdout = back_tick(['lipo', '-info', libname])
+        stdout = check_call(['lipo', '-info', libname])
     except RuntimeError:
         return frozenset()
     lines = [line.strip() for line in stdout.split('\n') if line.strip()]
@@ -498,8 +553,7 @@ def get_archs(libname):
         'Architectures in the fat file: {0} are: (.*)'.format(
                                                             re.escape(libname))
     ):
-        reggie = re.compile(reggie)
-        match = reggie.match(line)
+        match = re.match(reggie, line)
         if match is not None:
             return frozenset(match.groups()[0].split(' '))
     raise ValueError("Unexpected output: '{0}' for {1}".format(
@@ -507,6 +561,7 @@ def get_archs(libname):
 
 
 def lipo_fuse(in_fname1, in_fname2, out_fname):
+    # type: (Text, Text, Text) -> Text
     """ Use lipo to merge libs `filename1`, `filename2`, store in `out_fname`
 
     Parameters
@@ -518,13 +573,13 @@ def lipo_fuse(in_fname1, in_fname2, out_fname):
     out_fname : str
         filename to which to write new fused library
     """
-    return back_tick(['lipo', '-create',
-                      in_fname1, in_fname2,
-                      '-output', out_fname])
+    return check_call(
+        ['lipo', '-create', in_fname1, in_fname2, '-output', out_fname])
 
 
 @ensure_writable
 def replace_signature(filename, identity):
+    # type: (Text, Text) -> None
     """ Replace the signature of a binary file using `identity`
 
     See the codesign documentation for more info
@@ -536,11 +591,11 @@ def replace_signature(filename, identity):
     identity : str
         The signing identity to use.
     """
-    back_tick(['codesign', '--force', '--sign', identity, filename],
-              raise_err=True)
+    check_call(['codesign', '--force', '--sign', identity, filename])
 
 
 def validate_signature(filename):
+    # type: (Text) -> None
     """ Remove invalid signatures from a binary file
 
     If the file signature is missing or valid then it will be ignored
@@ -553,8 +608,7 @@ def validate_signature(filename):
     filename : str
         Filepath to a binary file
     """
-    out, err = back_tick(['codesign', '--verify', filename],
-                         ret_err=True, as_str=True, raise_err=False)
+    _, out, err = run_call(['codesign', '--verify', filename])
     if not err:
         return  # The existing signature is valid
     if 'code object is not signed at all' in err:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(name='delocate',
           "machomachomangler; sys_platform == 'win32'",
           "bindepend; sys_platform == 'win32'",
           "wheel",
+          "six",
+          "typing; python_version < '3.5'",
+          "typing_extensions",
       ],
       package_data={'delocate.tests':
                     [pjoin('data', '*.dylib'),
@@ -44,7 +47,9 @@ setup(name='delocate',
                      pjoin('data', 'test-lib'),
                      pjoin('data', '*patch'),
                      pjoin('data', 'make_libs.sh'),
-                     pjoin('data', 'icon.ico')]},
+                     pjoin('data', 'icon.ico')],
+                    'delocate': ['py.typed'],
+                    },
       entry_points={
           'console_scripts': [
               'delocate-{} = delocate.cmd.delocate_{}:main'.format(name, name)


### PR DESCRIPTION
Everything in the delocate directory with the exception of `_version.py` has been type annotated.

Code has been converted to use Unicode more often, this is enforced better in Python 2 via type hinting.  Six is used in some places to ensure compatibility with Python 2.  This can be implemented in the package itself if you don't like six for some reason.

`back_tick` was too polymorphic to gracefully type hint so it's been split into two calls.  `check_call` which is like `back_tick`'s default behavior and `run_call` which returns the error output instead of raising an exception.  In addition both functions take and return Unicode strings exclusively.  Tests and code have been updated with the new functions.  This is the best I can do without dropping Python 2.7 or adding `subprocess32`.

`InWheelCtx` violated its supertype by overriding `__enter__` with a different return type.  I've changed this class into a function with similar behavior.  `InWheelCtx` tests have not been changed.  MyPy doesn't like the tests but the current code will work well in practice.  This new function can be turned into a method of `InWheel` if you really want support for class inheritance.  `InWheelCtx` can also be a class that encapsulates `InWheel`, it just can't sub-class it.

The type hinting gives a better picture of how things are structured.  The common `lib_dict` type is `Dict[Text, Dict[Text, Text]]` and you can tell it's used pretty often.  If we wanted to refactor that type it can now be done pretty easily.

`py.typed` is PEP 561 and marks the package as supporting type hinting.  The GitHub actions support their own kind of annotations which should show errors in commits and pull requests.  The MyPy configuration is only set up to detect critical issues rather than most issues.