### PR TITLE
Respect namespace_packages when searching for packages

### DIFF
--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -176,7 +176,8 @@ def test_find_package_dirs():
         a_dir = pjoin('to_test', 'a_dir')
         b_dir = pjoin('to_test', 'b_dir')
         c_dir = pjoin('to_test', 'c_dir')
-        for dir in (a_dir, b_dir, c_dir):
+        dist_info_dir = 'test.dist-info'
+        for dir in (dist_info_dir, a_dir, b_dir, c_dir):
             os.mkdir(dir)
         assert_equal(find_package_dirs('to_test'), set([]))
         _write_file(pjoin(a_dir, '__init__.py'), "# a package")
@@ -185,6 +186,9 @@ def test_find_package_dirs():
         assert_equal(find_package_dirs('to_test'), {a_dir, c_dir})
         # Not recursive
         assert_equal(find_package_dirs('.'), set())
+        _write_file(pjoin(dist_info_dir, 'namespace_packages.txt'), "to_test\n")
+        assert find_package_dirs('.') == {a_dir, c_dir}
+        shutil.rmtree(dist_info_dir)
         _write_file(pjoin('to_test', '__init__.py'), "# base package")
         # Also - strips '.' for current directory
         assert_equal(find_package_dirs('.'), {'to_test'})

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -7,7 +7,6 @@ import sys
 import os
 from os.path import (join as pjoin, abspath, relpath, exists, sep as psep,
                      splitext, basename, dirname)
-import glob
 import hashlib
 import csv
 from itertools import product
@@ -19,7 +18,7 @@ try:
 except ImportError:  # As of Wheel 0.32.0
     from wheel.wheelfile import WheelFile
 from .tmpdirs import InTemporaryDirectory
-from .tools import unique_by_index, zip2dir, dir2zip, open_rw
+from .tools import find_dist_info, unique_by_index, zip2dir, dir2zip, open_rw
 
 
 class WheelToolsError(Exception):
@@ -45,13 +44,13 @@ def rewrite_record(bdist_dir):
     bdist_dir : str
         Path of unpacked wheel file
     """
-    info_dirs = glob.glob(pjoin(bdist_dir, '*.dist-info'))
-    if len(info_dirs) != 1:
+    info_dir = find_dist_info(bdist_dir)
+    if not info_dir:
         raise WheelToolsError("Should be exactly one `*.dist_info` directory")
-    record_path = pjoin(info_dirs[0], 'RECORD')
+    record_path = pjoin(info_dir, 'RECORD')
     record_relpath = relpath(record_path, bdist_dir)
     # Unsign wheel - because we're invalidating the record hash
-    sig_path = pjoin(info_dirs[0], 'RECORD.jws')
+    sig_path = pjoin(info_dir, 'RECORD.jws')
     if exists(sig_path):
         os.unlink(sig_path)
 


### PR DESCRIPTION
Namespace packes do not have a top level `__init__.py` - https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages
This causes delcoate to fail to find those packages.

setuptools will store the those values in `*.dist-info/namespace_packages.txt`
https://github.com/pypa/setuptools/blob/main/setup.py#L139

https://github.com/matthew-brett/delocate/pull/38 blindly globbed everything, this approaches it in a more
compliant way.