### PR TITLE
Updated multibuild to work around end of pip support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ matrix:
       # OS X 10.9
       - osx_image: beta-xcode6.1
       - env:
-          - MB_PYTHON_VERSION=2.7
+          - MB_PYTHON_VERSION=2.7.17
+          - MB_PYTHON_OSX_VER=10.6
           - BUILD_WHEELS=1
 
 install:


### PR DESCRIPTION
Updates multibuild to include https://github.com/matthew-brett/multibuild/pull/385, and then updates variables for the Python 2.7 job to fix a [failing build](https://travis-ci.org/github/radarhere/delocate/builds/760282731) (see https://github.com/matthew-brett/delocate/pull/86#issuecomment-751310477)

Suggested in https://github.com/matthew-brett/delocate/pull/86#issuecomment-784817548