### PR TITLE
Ad-hoc sign binaries after change

### DIFF
--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -273,5 +273,14 @@ def test_validate_signature():
         set_install_id('libcopy', 'libcopy-name')
         check_signature('libcopy')
 
-        set_install_name('libcopy', 'liba.dylib', 'liba0.dylib')
+        set_install_name('libcopy', '/usr/lib/libstdc++.6.dylib', '/usr/lib/libstdc++.7.dylib')
         check_signature('libcopy')
+
+        # check that altering the contents without ad-hoc sign invalidates
+        # signatures
+        set_install_id('libcopy', 'libcopy-name2', ad_hoc_sign=False)
+        assert_raises(RuntimeError, check_signature, 'libcopy')
+
+        set_install_name('libcopy', '/usr/lib/libstdc++.7.dylib', '/usr/lib/libstdc++.8.dylib',
+                         ad_hoc_sign=False)
+        assert_raises(RuntimeError, check_signature, 'libcopy')

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -9,7 +9,8 @@ import shutil
 from ..tools import (back_tick, unique_by_index, ensure_writable, chmod_perms,
                      ensure_permissions, parse_install_name, zip2dir, dir2zip,
                      find_package_dirs, cmp_contents, get_archs, lipo_fuse,
-                     replace_signature, validate_signature, add_rpath)
+                     replace_signature, validate_signature, add_rpath,
+                     set_install_id, set_install_name)
 
 from ..tmpdirs import InTemporaryDirectory
 

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -256,10 +256,15 @@ def test_validate_signature():
         check_signature('libcopy')  # codesign now accepts the file
 
         # Alter the contents of this file, this will invalidate the signature
-        add_rpath('libcopy', '/dummy/path')
+        add_rpath('libcopy', '/dummy/path', ad_hoc_sign=False)
 
         # codesign should raise a new error (invalid signature)
         assert_raises(RuntimeError, check_signature, 'libcopy')
 
         validate_signature('libcopy')  # Replace the broken signature
+        check_signature('libcopy')
+
+        # Alter the contents of this file, check that by default the file
+        # is signed with an ad-hoc signature
+        add_rpath('libcopy', '/dummy/path')
         check_signature('libcopy')

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -273,7 +273,8 @@ def test_validate_signature():
         set_install_id('libcopy', 'libcopy-name')
         check_signature('libcopy')
 
-        set_install_name('libcopy', '/usr/lib/libstdc++.6.dylib', '/usr/lib/libstdc++.7.dylib')
+        set_install_name('libcopy', '/usr/lib/libstdc++.6.dylib',
+                         '/usr/lib/libstdc++.7.dylib')
         check_signature('libcopy')
 
         # check that altering the contents without ad-hoc sign invalidates
@@ -281,6 +282,6 @@ def test_validate_signature():
         set_install_id('libcopy', 'libcopy-name2', ad_hoc_sign=False)
         assert_raises(RuntimeError, check_signature, 'libcopy')
 
-        set_install_name('libcopy', '/usr/lib/libstdc++.7.dylib', '/usr/lib/libstdc++.8.dylib',
-                         ad_hoc_sign=False)
+        set_install_name('libcopy', '/usr/lib/libstdc++.7.dylib',
+                         '/usr/lib/libstdc++.8.dylib', ad_hoc_sign=False)
         assert_raises(RuntimeError, check_signature, 'libcopy')

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -266,5 +266,5 @@ def test_validate_signature():
 
         # Alter the contents of this file, check that by default the file
         # is signed with an ad-hoc signature
-        add_rpath('libcopy', '/dummy/path')
+        add_rpath('libcopy', '/dummy/path2')
         check_signature('libcopy')

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -268,3 +268,9 @@ def test_validate_signature():
         # is signed with an ad-hoc signature
         add_rpath('libcopy', '/dummy/path2')
         check_signature('libcopy')
+
+        set_install_id('libcopy', 'libcopy-name')
+        check_signature('libcopy')
+
+        set_install_name('libcopy', 'liba.dylib', 'liba0.dylib')
+        check_signature('libcopy')

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -533,8 +533,8 @@ def lipo_fuse(in_fname1, in_fname2, out_fname, ad_hoc_sign=True):
         sign the new library with an ad hoc signature or not
     """
     out = back_tick(['lipo', '-create',
-                      in_fname1, in_fname2,
-                      '-output', out_fname])
+                     in_fname1, in_fname2,
+                     '-output', out_fname])
     if ad_hoc_sign:
         replace_signature(out_fname, '-')
     return out

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -262,8 +262,8 @@ def set_install_name(filename, oldname, newname, ad_hoc_sign=True):
         current install name in library
     newname : str
         replacement name for `oldname`
-    ad_hoc_sign : bool
-        sign the new library with an ad hoc signature or not
+    ad_hoc_sign : {True, False}, optional
+        If True, sign library with ad-hoc signature
     """
     names = get_install_names(filename)
     if oldname not in names:
@@ -371,8 +371,8 @@ def add_rpath(filename, newpath, ad_hoc_sign=True):
         filename of library
     newpath : str
         rpath to add
-    ad_hoc_sign : bool
-        sign the new library with an ad hoc signature or not
+    ad_hoc_sign : {True, False}, optional
+        If True, sign file with ad-hoc signature
     """
     back_tick(['install_name_tool', '-add_rpath', newpath, filename])
     if ad_hoc_sign:
@@ -529,8 +529,8 @@ def lipo_fuse(in_fname1, in_fname2, out_fname, ad_hoc_sign=True):
         filename of library
     out_fname : str
         filename to which to write new fused library
-    ad_hoc_sign : bool
-        sign the new library with an ad hoc signature or not
+    ad_hoc_sign : {True, False}, optional
+        If True, sign file with ad-hoc signature
     """
     out = back_tick(['lipo', '-create',
                      in_fname1, in_fname2,

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -271,6 +271,8 @@ def set_install_name(filename, oldname, newname, ad_hoc_sign=True):
             oldname, filename))
     back_tick(['install_name_tool', '-change', oldname, newname, filename])
     if ad_hoc_sign:
+        # ad hoc signature is represented by a dash
+        # https://developer.apple.com/documentation/security/seccodesignatureflags/kseccodesignatureadhoc
         replace_signature(filename, '-')
 
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -284,8 +284,8 @@ def set_install_id(filename, install_id, ad_hoc_sign=True):
         filename of library
     install_id : str
         install id for library `filename`
-    ad_hoc_sign : bool
-        sign the new library with an ad hoc signature or not
+    ad_hoc_sign : {True, False}, optional
+        If True, sign library with ad-hoc signature
 
     Raises
     ------


### PR DESCRIPTION
cc @mattip

In macOS arm64, all executables and shared libraries are required to be signed with a valid signature and it can be an ad-hoc signature. Otherwise the process is killed.