### PR TITLE
Updated URL

### DIFF
--- a/doc/links_names.inc
+++ b/doc/links_names.inc
@@ -9,7 +9,7 @@
    nipy, NIPY, Nipy, etc...
 
 .. _delocate github: http://github.com/matthew-brett/delocate
-.. _delocate pypi: http://pypi.python.org/pypi/delocate
+.. _delocate pypi: https://pypi.org/project/delocate
 .. _delocate issues: http://github.com/matthew-brett/delocate/issues
 .. _delocate travis-ci: https://travis-ci.org/matthew-brett/delocate
 .. _versioneer: https://github.com/warner/python-versioneer


### PR DESCRIPTION
Navigating to http://pypi.python.org/pypi/delocate in your browser, you are redirected to https://pypi.org/project/delocate/