### PR TITLE
Update Flake8 config and workflow.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 80
 per-file-ignores =
-    setup.py: F401 E402
     delocate/tmpdirs.py: E266
+select = E,F,W
+ignore = W503,W504
 exclude = versioneer.py delocate/_version.py

--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -8,19 +8,18 @@ jobs:
   flake8:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
-    - name: Install Flake8
-      run: |
-        pip install flake8
-    - name: Run Flake8
-      uses: suo/flake8-github-action@releases/v1
-      with:
-        checkName: 'flake8'  # NOTE: this needs to be the same as the job name.
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install Flake8
+        run: |
+          pip install flake8
+      - name: Run Flake8
+        uses: liskin/gh-problem-matcher-wrap@v1
+        with:
+          linters: flake8
+          run: flake8 .
 
   mypy:
     runs-on: ubuntu-20.04

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -346,16 +346,12 @@ def _copy_required(
         copied_libs[required] = procd_requirings
 
 
-def _dylibs_only(filename):
-    # type: (Text) -> bool
-    return (filename.endswith('.so') or
-            filename.endswith('.dylib'))
+def _dylibs_only(filename: str) -> bool:
+    return filename.endswith('.so') or filename.endswith('.dylib')
 
 
-def filter_system_libs(libname):
-    # type: (Text) -> bool
-    return not (libname.startswith('/usr/lib') or
-                libname.startswith('/System'))
+def filter_system_libs(libname: str) -> bool:
+    return not (libname.startswith('/usr/lib') or libname.startswith('/System'))
 
 
 def delocate_path(

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -414,8 +414,8 @@ def resolve_rpath(lib_path, rpaths):
         "Couldn't find {0} on paths:\n\t{1}".format(
             lib_path,
             '\n\t'.join(realpath(path) for path in rpaths),
-            )
         )
+    )
     return lib_path
 
 

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -54,7 +54,7 @@ def _make_libtree(out_path):
         (slibc, 'liba.dylib', out_path),
         (slibc, 'libb.dylib', out_path),
         (stest_lib, 'libc.dylib', sub_path),
-                        ):
+    ):
         set_install_name(fname, using, pjoin(path, using))
     # Check scripts now execute correctly
     back_tick([test_lib])
@@ -501,9 +501,7 @@ def test_check_archs():
          LIB64: {LIBM1: 'install_name'}}),
         {(LIB64, LIBM1, ARCH_M1)})
     # For single archs depending, dual archs in depended is OK
-    assert_equal(check_archs(
-        {LIBBOTH: {LIB64A: 'install_name'}}),
-         s0)
+    assert check_archs({LIBBOTH: {LIB64A: 'install_name'}}) == s0
     # For dual archs in depending, both must be present
     assert_equal(check_archs(
         {LIBBOTH: {LIBBOTH: 'install_name'}}),

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -51,10 +51,13 @@ def test_tree_libs():
         liba, libb, libc, test_lib = local_libs
         rp_liba, rp_libb, rp_libc, rp_test_lib = rp_local_libs
         exp_dict = get_ext_dict(local_libs)
-        exp_dict.update({
-             rp_liba: {rp_libb: 'liba.dylib', rp_libc: 'liba.dylib'},
-             rp_libb: {rp_libc: 'libb.dylib'},
-             rp_libc: {rp_test_lib: 'libc.dylib'}})
+        exp_dict.update(
+            {
+                rp_liba: {rp_libb: 'liba.dylib', rp_libc: 'liba.dylib'},
+                rp_libb: {rp_libc: 'libb.dylib'},
+                rp_libc: {rp_test_lib: 'libc.dylib'}
+            }
+        )
         # default - no filtering
         assert tree_libs(tmpdir) == exp_dict
 
@@ -62,9 +65,12 @@ def test_tree_libs():
             # type: (Text) -> bool
             return fname.endswith('.dylib')
         exp_dict = get_ext_dict([liba, libb, libc])
-        exp_dict.update({
-             rp_liba: {rp_libb: 'liba.dylib', rp_libc: 'liba.dylib'},
-             rp_libb: {rp_libc: 'libb.dylib'}})
+        exp_dict.update(
+            {
+                rp_liba: {rp_libb: 'liba.dylib', rp_libc: 'liba.dylib'},
+                rp_libb: {rp_libc: 'libb.dylib'}
+            }
+        )
         # filtering
         assert tree_libs(tmpdir, filt) == exp_dict
         # Copy some libraries into subtree to test tree walking

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -340,7 +340,7 @@ def get_rpaths(filename):
         line_no += 1
         if line != 'cmd LC_RPATH':
             continue
-        cmdsize, path = lines[line_no:line_no+2]
+        cmdsize, path = lines[line_no:line_no + 2]
         assert cmdsize.startswith('cmdsize ')
         paths.append(RPATH_RE.match(path).groups()[0])
         line_no += 2
@@ -518,7 +518,8 @@ def get_archs(libname):
     for reggie in (
         'Non-fat file: {0} is architecture: (.*)'.format(re.escape(libname)),
         'Architectures in the fat file: {0} are: (.*)'.format(
-                                                            re.escape(libname))
+            re.escape(libname)
+        )
     ):
         reggie = re.compile(reggie)
         match = reggie.match(line)

--- a/wheel_makers/fakepkg2/setup.py
+++ b/wheel_makers/fakepkg2/setup.py
@@ -3,8 +3,7 @@
 fakepkg2 is a - fake package - with Python only. We use it to build a wheel,
 then test we can delocate it.
 """
-import setuptools  # for wheel builds
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='fakepkg2',

--- a/wheel_makers/fakepkg_rpath/setup.py
+++ b/wheel_makers/fakepkg_rpath/setup.py
@@ -56,5 +56,5 @@ setup(
         'fakepkg',
         'fakepkg.subpkg',
         'fakepkg.tests',
-        ],
+    ],
 )


### PR DESCRIPTION
This sets which error codes to select and ignore.  The previous config was using parts of my local configuration which was undesirable.

The GitHub workflow now uses a simpler problem matcher action and was reformatted.

Any new Flake8 errors were fixed.