### PR TITLE
Support public code coverage statistics.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install delocate
         run: |
           python setup.py develop bdist_wheel
+      - name: Upload wheel
+        uses: actions/upload-artifact@v2
+        with:
+          name: delocate-wheel
+          path: |
+            dist/delocate-*.whl
+          retention-days: 3
+          if-no-files-found: error
       - name: Run tests
         run: |
           pytest --pyargs delocate --log-level DEBUG --cov-config=.coveragerc --cov=delocate
@@ -56,3 +64,31 @@ jobs:
         with:
           fail_ci_if_error: true
           token: "624762bf-aaf0-4a75-b450-16f5ebece0b1"
+
+  isolated_tests:
+    needs: tests
+    runs-on: macos-10.15
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "12.4"
+      - name: Workaround ARM64 issues
+        # https://github.com/actions/virtual-environments/issues/2557
+        run: |
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+      - name: Download wheel
+        uses: actions/download-artifact@v2
+        with:
+          name: delocate-wheel
+      - name: Install delocate
+        run: |
+          pip install delocate-*.whl
+      - name: Install test dependencies
+        run: |
+          pip install pytest
+      - name: Run isolated tests
+        run: |
+          pytest --pyargs delocate --log-level DEBUG

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,7 +44,15 @@ jobs:
           pip install -r test-requirements.txt
       - name: Install delocate
         run: |
-          pip install . --use-feature=in-tree-build
+          python setup.py develop bdist_wheel
       - name: Run tests
         run: |
-          mkdir tmp && cd tmp && pytest --pyargs delocate --log-level DEBUG
+          pytest --pyargs delocate --log-level DEBUG --cov-config=.coveragerc --cov=delocate
+      - name: Collect code coverage data
+        run: |
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          token: "624762bf-aaf0-4a75-b450-16f5ebece0b1"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
       - name: Install test dependencies
         run: |
-          pip install -r test-requirements.txt
+          pip install -r test-requirements.txt pytest-cov
       - name: Install delocate
         run: |
           python setup.py develop bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 .. image:: https://travis-ci.org/matthew-brett/delocate.svg?branch=master
     :target: https://travis-ci.org/matthew-brett/delocate
+.. image:: https://codecov.io/gh/matthew-brett/delocate/branch/master/graph/badge.svg?token=wvAWRBK5Di
+    :target: https://codecov.io/gh/matthew-brett/delocate
 
 ########
 Delocate

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 # Requirements for tests
 wheel
 pytest
+pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 # Requirements for tests
 wheel
 pytest
-pytest-cov


### PR DESCRIPTION
Added the code coverage tools to the workflow.  There's an option to set up a YAML file but it isn't required and I haven't done it.

[The public site is here.](https://app.codecov.io/gh/matthew-brett/delocate/branch/codecov)  It already shows the coverage of my PR.  I've added a badge to the readme.

I don't really know how to handle coverage correctly without doing a development install.  I now run two tests, one for code coverage and one that's isolated from the repository.