### PR TITLE
MRG: fix for docstring

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -555,8 +555,8 @@ def delocate_wheel(
         to sequence ``['x86_64, 'i386']``) or name of required architecture
         (e.g "i386" or "x86_64").
     check_verbose : bool, optional
-        This flag is deprecated and shouldn't be provided.
-    executable_path : str, optional, keyword-only
+        This flag is deprecated, and has no effect.
+    executable_path : None or str, optional, keyword-only
         An alternative path to use for resolving `@executable_path`.
     ignore_missing : bool, default=False, keyword-only
         Continue even if missing dependencies are detected.
@@ -575,7 +575,7 @@ def delocate_wheel(
     if check_verbose is not None:
         warnings.warn(
             "The check_verbose flag is deprecated and shouldn't be provided,"
-            " all remaining parameters should be changed over to keywords.",
+            " all subsequent parameters should be changed over to keywords.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
I played with *args and **kwargs to warn on positional arguments here, but all
the solutions looked like they would make type-hinting more obscure, so I gave
up.

We can just raise an error for non-keyword arguments later.  It's a pretty
obvious fix for our users.