### PR TITLE
Deprecate and replace calls to back_tick.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -30,6 +30,8 @@ Releases
     [#123](https://github.com/matthew-brett/delocate/pull/123)
   * Wheels with multiple packages will no longer copy duplicate libraries.
     [#35](https://github.com/matthew-brett/delocate/issues/35)
+  * ``delocate.tools.back_tick`` has been deprecated.
+    [#126](https://github.com/matthew-brett/delocate/pull/126)
 
 * 0.9.1 (Friday September 17th 2021)
 

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -4,6 +4,7 @@
 import os
 from os.path import join as pjoin, exists, isfile, basename, realpath, splitext
 import shutil
+from typing import AnyStr
 
 try:
     from wheel.install import WheelFile
@@ -37,9 +38,8 @@ EXTRA_EXPS = [('Generator', 'bdist_wheel {pip_version}'),
                   for plat in (EXP_PLAT,) + EXTRA_PLATS]
 
 
-def assert_record_equal(record_orig, record_new):
-    assert_equal(sorted(record_orig.splitlines()),
-                 sorted(record_new.splitlines()))
+def assert_record_equal(record_orig: AnyStr, record_new: AnyStr) -> None:
+    assert sorted(record_orig.splitlines()) == sorted(record_new.splitlines())
 
 
 def test_rewrite_record():


### PR DESCRIPTION
Related to #125

The non-specific timeout check in `back_tick` has been removed.  It was that or provide a specific timeout time.

All internal functions and tests now use `subprocess.run`.  This might change some of the exceptions raised by those functions except for `lipo_fuse` which was specifically tested to raise `RuntimeError`.

Relevant tests have been cleaned up.

Relevant functions have had type annotations added/updated.

Ready to merge after review.