### PR TITLE
Update `parse_install_name` to the latest format.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,10 +80,6 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ matrix.xcode }}
-      - name: Workaround ARM64 issues
-        # https://github.com/actions/virtual-environments/issues/2557
-        run: |
-          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,11 +67,19 @@ jobs:
 
   isolated_tests:
     needs: tests
-    runs-on: macos-10.15
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: "macos-10.15"
+            xcode: "12.4"
+          - os: "macos-11"
+            xcode: "13.0"
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "12.4"
+          xcode-version: ${{ matrix.xcode }}
       - name: Workaround ARM64 issues
         # https://github.com/actions/virtual-environments/issues/2557
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+      - name: Check otool version
+        run: otool --version
       - name: Download wheel
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
       - name: Install test dependencies
         run: |
-          pip install -r test-requirements.txt pytest-cov
+          pip install -r test-requirements.txt
       - name: Install delocate
         run: |
           python setup.py develop bdist_wheel
@@ -55,7 +55,7 @@ jobs:
           if-no-files-found: error
       - name: Run tests
         run: |
-          pytest --pyargs delocate --log-level DEBUG --cov-config=.coveragerc --cov=delocate --doctest-modules
+          pytest
       - name: Collect code coverage data
         run: |
           coverage xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 install:
   - source multibuild/osx_utils.sh
   - get_macpython_environment $MB_PYTHON_VERSION venv
-  - pip install $WHEEL_SPEC pytest
+  - pip install $WHEEL_SPEC -r test-requirements.txt
   - if [ -n "$BUILD_WHEELS" ]; then
         (make clean && make);
     fi
@@ -50,7 +50,6 @@ script:
     cd tmp_test_dir
     if [ -n "$COVERAGE" ]; then
       cp ../.coveragerc .
-      pip install pytest-cov
       COVER_ARGS="--cov=$PKG_NAME"
     fi
     pytest $COVER_ARGS --pyargs $PKG_NAME --log-level DEBUG

--- a/Changelog
+++ b/Changelog
@@ -24,6 +24,9 @@ Releases
   * Ensured support for versions of wheel beyond 0.37.1.  If you are using older
     versions of Delcoate then you may need to to pin ``wheel==0.37.1``.
     [#135](https://github.com/matthew-brett/delocate/issues/135)
+  * Fixed crashes when ``otool`` gives multiple architectures in its output.
+    This does not support different dependencies per-architecture.
+    [#130](https://github.com/matthew-brett/delocate/pull/130)
 
 * [0.10.1] - 2021-11-23
 

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -38,36 +38,33 @@ PY_FILE = pjoin(DATA_PATH, "some_code.py")
 BIN_FILE = pjoin(DATA_PATH, "binary_example.bin")
 
 
-def test_get_install_names():
+def test_get_install_names() -> None:
     # Test install name listing
-    assert_equal(set(get_install_names(LIBA)), set(EXT_LIBS))
-    assert_equal(set(get_install_names(LIBB)), set(("liba.dylib",) + EXT_LIBS))
-    assert_equal(
-        set(get_install_names(LIBC)),
-        set(("liba.dylib", "libb.dylib") + EXT_LIBS),
+    assert set(get_install_names(LIBA)) == set(EXT_LIBS)
+    assert set(get_install_names(LIBB)) == set(("liba.dylib",) + EXT_LIBS)
+    assert set(get_install_names(LIBC)) == set(
+        ("liba.dylib", "libb.dylib") + EXT_LIBS
     )
-    assert_equal(
-        set(get_install_names(TEST_LIB)), set(("libc.dylib",) + EXT_LIBS)
-    )
-    assert_equal(set(get_install_names(LIBAM1_ARCH)), set(EXT_LIBS))
+    assert set(get_install_names(TEST_LIB)) == set(("libc.dylib",) + EXT_LIBS)
+    assert set(get_install_names(LIBAM1_ARCH)) == set(EXT_LIBS)
     # Non-object file returns empty tuple
-    assert_equal(get_install_names(__file__), ())
+    assert get_install_names(__file__) == ()
     # Static archive and object files returns empty tuple
-    assert_equal(get_install_names(A_OBJECT), ())
-    assert_equal(get_install_names(LIBA_STATIC), ())
+    assert get_install_names(A_OBJECT) == ()
+    assert get_install_names(LIBA_STATIC) == ()
     # ico file triggers another error message and should also return an empty tuple  # noqa: E501
-    assert_equal(get_install_names(ICO_FILE), ())
+    assert get_install_names(ICO_FILE) == ()
     # Python file (__file__ above may be a pyc file)
-    assert_equal(get_install_names(PY_FILE), ())
+    assert get_install_names(PY_FILE) == ()
     # Binary file (in fact a truncated SAS file)
-    assert_equal(get_install_names(BIN_FILE), ())
+    assert get_install_names(BIN_FILE) == ()
     # Test when no read permission
     with InTemporaryDirectory():
         shutil.copyfile(LIBA, "test.dylib")
-        assert_equal(set(get_install_names("test.dylib")), set(EXT_LIBS))
+        assert set(get_install_names("test.dylib")) == set(EXT_LIBS)
         # No permissions, no found libs
         os.chmod("test.dylib", 0)
-        assert_equal(get_install_names("test.dylib"), ())
+        assert get_install_names("test.dylib") == ()
 
 
 def test_parse_install_name():

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -140,7 +140,7 @@ def test_ensure_writable():
         assert_equal(os.stat("test.bin"), st)
 
 
-def test_parse_install_name():
+def test_parse_install_name() -> None:
     # otool on versions previous to Catalina
     line0 = (
         "/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore "
@@ -158,6 +158,10 @@ def test_parse_install_name():
         "(compatibility version 1.2.0, current version 1.11.0, weak)"
     )
     assert parse_install_name(line1) == (name, cpver, cuver)
+
+    # Test bad input.
+    with pytest.raises(ValueError, match="Could not parse.*bad-str"):
+        parse_install_name("bad-str")
 
 
 def _write_file(filename, contents):

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -281,7 +281,7 @@ def _parse_otool_listing(stdout: str) -> Dict[str, List[str]]:
     return out
 
 
-def _ignore_architectures(input: Dict[str, T]) -> T:
+def _check_ignore_archs(input: Dict[str, T]) -> T:
     """Merge architecture outputs for functions which don't support multiple.
 
     This is used to maintain backward compatibility inside of functions which
@@ -308,13 +308,13 @@ def _ignore_architectures(input: Dict[str, T]) -> T:
     Examples
     --------
     >>> values = {"a": 10, "b": 10}
-    >>> _ignore_architectures(values)
+    >>> _check_ignore_archs(values)
     10
     >>> values
     {'a': 10, 'b': 10}
-    >>> _ignore_architectures({"": ["1", "2", "2"]})
+    >>> _check_ignore_archs({"": ["1", "2", "2"]})
     ['1', '2', '2']
-    >>> _ignore_architectures({"a": "1", "b": "not 1"})
+    >>> _check_ignore_archs({"a": "1", "b": "not 1"})
     Traceback (most recent call last):
         ...
     delocate.tools.InstallNameError: ...
@@ -442,7 +442,7 @@ def get_install_names(filename: str) -> Tuple[str, ...]:
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()
     install_id = get_install_id(filename)
-    names_data = _ignore_architectures(_parse_otool_install_names(otool.stdout))
+    names_data = _check_ignore_archs(_parse_otool_install_names(otool.stdout))
     names = [name for name, _, _ in names_data]
     if install_id:  # Remove redundant install id from the install names.
         if names[0] != install_id:
@@ -471,7 +471,7 @@ def get_install_id(filename: str) -> Optional[str]:
     install_ids = _get_install_ids(filename)
     if not install_ids:
         return None  # No install ids or nothing returned.
-    return _ignore_architectures(install_ids)
+    return _check_ignore_archs(install_ids)
 
 
 def _get_install_ids(filename: str) -> Dict[str, str]:
@@ -658,7 +658,7 @@ def get_rpaths(filename: str) -> Tuple[str, ...]:
     )
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()
-    rpaths = _ignore_architectures(_parse_otool_rpaths(otool.stdout))
+    rpaths = _check_ignore_archs(_parse_otool_rpaths(otool.stdout))
     return tuple(rpaths)
 
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -319,8 +319,8 @@ def _ignore_architectures(input: Dict[str, T]) -> T:
         ...
     delocate.tools.InstallNameError: ...
     """
-    first = next(iter(input.values()))  # Get any one value non-destructively.
-    if any(first != others for others in input.values()):
+    first, *rest = input.values()
+    if any(first != others for others in rest):
         raise InstallNameError(
             "This function does not support separate values per-architecture:"
             f" {input}"

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -408,15 +408,15 @@ def get_install_id(filename: str) -> Optional[str]:
         install id of library `filename`, or None if no install id
     """
     install_ids = _get_install_ids(filename)
-    if all(not install_id for install_id in install_ids.values()):
+    unique_ids = set(install_ids.values())
+    if not unique_ids:
         return None  # No install ids or nothing returned.
-    my_id = list(install_ids.values())[0]
-    if any(install_id != my_id for install_id in install_ids.values()):
+    if len(unique_ids) > 1:
         raise InstallNameError(
             "This function does not support separate install ids"
             f" per-architecture: {install_ids}"
         )
-    return my_id  # Only one install name.
+    return unique_ids.pop()
 
 
 def _get_install_ids(filename: str) -> Dict[str, str]:

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -193,7 +193,7 @@ def parse_install_name(line: str) -> Tuple[str, str, str]:
 _OTOOL_ARCHITECTURE_RE = re.compile(
     r"^(?P<name>.*?)(?: \(architecture (?P<architecture>\w+)\))?:$"
 )
-"""Matches the library separater line in 'otool -L'-like outputs.
+"""Matches the library separator line in 'otool -L'-like outputs.
 
 Examples
 --------

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -9,7 +9,7 @@ import zipfile
 from os.path import exists, isdir
 from os.path import join as pjoin
 from os.path import relpath
-from typing import Any, FrozenSet, List, Optional, Sequence, Set, Union
+from typing import Any, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
 
 
 class InstallNameError(Exception):
@@ -147,7 +147,7 @@ IN_RE = re.compile(
 )
 
 
-def parse_install_name(line):
+def parse_install_name(line: str) -> Tuple[str, str, str]:
     """Parse a line of install name output
 
     Parameters
@@ -165,7 +165,11 @@ def parse_install_name(line):
         current version
     """
     line = line.strip()
-    return IN_RE.match(line).groups()
+    match = IN_RE.match(line)
+    if not match:
+        raise ValueError(f"Could not parse {line!r}")
+    libname, compat_version, current_version = match.groups()
+    return libname, compat_version, current_version
 
 
 # otool -L strings indicating this is not an object file. The string changes
@@ -229,7 +233,7 @@ def _line0_says_object(line0, filename):
     )
 
 
-def get_install_names(filename):
+def get_install_names(filename: str) -> Tuple[str, ...]:
     """Return install names from library named in `filename`
 
     Returns tuple of install names

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -192,9 +192,18 @@ _OTOOL_ARCHITECTURE_RE = re.compile(
 )
 """Matches the library separater line in 'otool -L'-like outputs.
 
-Must match the following examples:
-'example.so (architecture x86_64):'
-'example.so:'
+Examples
+--------
+>>> match = _OTOOL_ARCHITECTURE_RE.match("example.so (architecture x86_64):")
+>>> match["name"]
+'example.so'
+>>> match["architecture"]
+'x86_64'
+>>> match = _OTOOL_ARCHITECTURE_RE.match("example.so:")
+>>> match["name"]
+'example.so'
+>>> match["architecture"] is None
+True
 """
 
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -445,7 +445,10 @@ def get_install_names(filename: str) -> Tuple[str, ...]:
     names_data = _ignore_architectures(_parse_otool_install_names(otool.stdout))
     names = [name for name, _, _ in names_data]
     if install_id:  # Remove redundant install id from the install names.
-        assert names[0] == install_id
+        if names[0] != install_id:
+            raise RuntimeError(
+                f"Expected {install_id!r} to be first in {names}"
+            )
         names = names[1:]
     return tuple(names)
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -501,8 +501,13 @@ def _get_install_ids(filename: str) -> Dict[str, str]:
     out = {}
     for arch, my_id_list in _parse_otool_listing(otool.stdout).items():
         if not my_id_list:
-            continue
-        (out[arch],) = my_id_list  # List should always have 0 or 1 items.
+            continue  # No install ID.
+        if len(my_id_list) != 1:
+            raise RuntimeError(
+                "Expected at most 1 value for a libraries install ID,"
+                f" got {my_id_list}"
+            )
+        out[arch] = my_id_list[0]
     return out
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,10 @@ py_version = 36
 src_paths = ["isort", "test"]
 line_length = 80
 extend_skip = ["versioneer.py", "delocate/_version.py"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+required_plugins = ["pytest-cov"]
+testpaths = ["delocate/"]
+addopts = ["--doctest-modules", "--cov=delocate", "--cov-config=.coveragerc"]
+log_file_level = "DEBUG"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 # Requirements for tests
 wheel
 pytest
+pytest-cov


### PR DESCRIPTION
It's likely that `otool` changed its output since #78 and `parse_install_name` needs to be updated again.

So far this changes the function so that it outputs the input string when it fails, which will make this easier to fix in the future.  I also added tests for macOS 11 and Xcode 13 but they didn't fail.

Refactors how otool install names are parsed which fixes #78.