### PR TITLE
Avoid duplication when library has soft links and been used in the same wheels.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -21,6 +21,10 @@ Releases
 
 * [Unreleased]
 
+  * Delocate will no longer fail when libraries use different install names to
+    refer to the same library.
+    [#134](https://github.com/matthew-brett/delocate/pull/134)
+
 * [0.10.0] - 2021-09-22
 
   First release that requires Python 3.

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -625,7 +625,7 @@ def search_environment_for_lib(lib_path):
 
     for location in potential_library_locations:
         if os.path.exists(location):
-            return location
+            return realpath(location)
     return realpath(lib_path)
 
 

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -604,7 +604,7 @@ def search_environment_for_lib(lib_path):
     Returns
     -------
     lib_path : str
-        Full path of ``basename(lib_path)``'s location, if it can be found, or
+        Real path of the first found location, if it can be found, or
         ``realpath(lib_path)`` if it cannot.
     """
     lib_basename = basename(lib_path)
@@ -625,6 +625,7 @@ def search_environment_for_lib(lib_path):
 
     for location in potential_library_locations:
         if os.path.exists(location):
+            # See GH#133 for why we return the realpath here if it can be found
             return realpath(location)
     return realpath(lib_path)
 

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -682,7 +682,7 @@ def test_dyld_library_path_beats_basename():
         # Updating shows us the new lib
         os.environ["DYLD_LIBRARY_PATH"] = subdir
         predicted_lib_location = search_environment_for_lib(libb)
-        assert_equal(predicted_lib_location, new_libb)
+        assert_equal(predicted_lib_location, realpath(new_libb))
 
 
 def test_dyld_fallback_library_path_loses_to_basename():

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -302,7 +302,7 @@ def test_tree_libs_from_directory_with_links() -> None:
                 libb_use_link,
             ]
         )
-        # hack libb.dylib to resolving from rpath, bypass searching from env
+        # hack libb.dylib to resolve from rpath, bypass searching from env
         subprocess.check_call(
             [
                 "install_name_tool",

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -334,7 +334,10 @@ def test_tree_libs_from_directory_with_links() -> None:
 
         # Put dir of soft link for `liba.dylib` into `DYLD_LIBRARY_PATH`
         with TempDirWithoutEnvVars("DYLD_LIBRARY_PATH"):
-            assert tree_libs_from_directory(tmpdir) != exp_dict
+            # the result should be correct normally
+            assert tree_libs_from_directory(tmpdir) == exp_dict
+
+            # the result should be correct even if there are soft links in `$DYLD_LIBRARY_PATH`
             os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
             assert tree_libs_from_directory(tmpdir) == exp_dict
 

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -332,15 +332,10 @@ def test_tree_libs_from_directory_with_links() -> None:
         )
 
         # Put dir of soft link for `liba.dylib` into `DYLD_LIBRARY_PATH`
-        dyld_library_path = os.environ.get("DYLD_LIBRARY_PATH")
-        os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
-        try:
+        with TempDirWithoutEnvVars("DYLD_LIBRARY_PATH"):
+            assert tree_libs_from_directory(tmpdir) != exp_dict
+            os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
             assert tree_libs_from_directory(tmpdir) == exp_dict
-        finally:  # Restore os.environ.
-            if dyld_library_path is not None:
-                os.environ["DYLD_LIBRARY_PATH"] = dyld_library_path
-            else:
-                del os.environ["DYLD_LIBRARY_PATH"]
 
 
 def test_get_prefix_stripper():

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -331,7 +331,7 @@ def test_tree_libs_from_directory_with_links() -> None:
             }
         )
 
-        # makes the soft link of `liba.dylib` presents in `DYLD_LIBRARY_PATH`
+        # Put dir of soft link for `liba.dylib` into `DYLD_LIBRARY_PATH`
         dyld_library_path = os.environ.get("DYLD_LIBRARY_PATH")
         os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
         try:

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -255,7 +255,6 @@ def test_tree_libs_from_directory() -> None:
 def test_tree_libs_from_directory_with_links() -> None:
     # Test ability to walk through tree, where the same library may have
     # soft links under different subdirectories. See also GH#133, where
-    #
     # we have:
     #
     #   liba.dylib

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -292,7 +292,7 @@ def test_tree_libs_from_directory_with_links() -> None:
         os.symlink(liba, liba_link)
         shutil.copy2(libb, libb_use_link)
 
-        # hack links/libb.dylib to depends on the softlink of liba.dylib
+        # hack links/libb.dylib to depend on the softlink of liba.dylib
         subprocess.check_call(
             [
                 "install_name_tool",

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -337,7 +337,8 @@ def test_tree_libs_from_directory_with_links() -> None:
             # the result should be correct normally
             assert tree_libs_from_directory(tmpdir) == exp_dict
 
-            # the result should be correct even if there are soft links in `$DYLD_LIBRARY_PATH`
+            # the result should be correct even if there are soft links in
+            # `$DYLD_LIBRARY_PATH`
             os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
             assert tree_libs_from_directory(tmpdir) == exp_dict
 

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -30,6 +30,7 @@ from ..libsana import (
 )
 from ..tmpdirs import InTemporaryDirectory
 from ..tools import set_install_name
+from .env_tools import TempDirWithoutEnvVars
 from .pytest_tools import assert_equal
 from .test_install_names import (
     DATA_PATH,

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -333,22 +333,15 @@ def test_tree_libs_from_directory_with_links() -> None:
         )
 
         # makes the soft link of `liba.dylib` presents in `DYLD_LIBRARY_PATH`
-        dyld_library_path = os.environ.get("dyld_library_path", None)
-        new_dyld_library_path = os.path.dirname(liba_link)
-        if dyld_library_path is not None:
-            new_dyld_library_path = os.path.pathsep.join(
-                new_dyld_library_path, dyld_library_path
-            )
-        os.environ["DYLD_LIBRARY_PATH"] = new_dyld_library_path
-
-        # check the result
-        assert tree_libs_from_directory(tmpdir) == exp_dict
-
-        # restore os environment
-        if dyld_library_path is not None:
-            os.environ["DYLD_LIBRARY_PATH"] = dyld_library_path
-        else:
-            del os.environ["DYLD_LIBRARY_PATH"]
+        dyld_library_path = os.environ.get("DYLD_LIBRARY_PATH")
+        os.environ["DYLD_LIBRARY_PATH"] = os.path.dirname(liba_link)
+        try:
+            assert tree_libs_from_directory(tmpdir) == exp_dict
+        finally:  # Restore os.environ.
+            if dyld_library_path is not None:
+                os.environ["DYLD_LIBRARY_PATH"] = dyld_library_path
+            else:
+                del os.environ["DYLD_LIBRARY_PATH"]
 
 
 def test_get_prefix_stripper():


### PR DESCRIPTION
Resolves issue #133.

I have managed to reproduce the issue by the following minimal case:

We have:

```
  liba.dylib
  links/liba.dylib, a soft link to liba.dylib
```

and

```
  libb.dylib, depends on liba.dylib via `@rpath/liba.dylib`
  links/libb.dylib, depends on links/liba.dylib and been found via `DYLD_LIBRARY_PATH`
```

During resolving dependencies, the first is found via resolving from `@rpath` by `resolve_dynamic_paths`, and the later is resolved from `DYLD_LIBRARY_PATH` by `search_environment_for_lib`, where the soft link path is returned, thus the conflicit happens.

For more details, see the minimal reproduce case in `test_tree_libs_from_directory_with_links`, and we have verified the patch in our real-world wheels that triggerred #133 before.