### PR TITLE
Replicate the to-be-removed `wheel.pkginfo` module.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -21,6 +21,10 @@ Releases
 
 * [Unreleased]
 
+  * Ensured support for versions of wheel beyond 0.37.1.  If you are using older
+    versions of Delcoate then you may need to to pin ``wheel==0.37.1``.
+    [#135](https://github.com/matthew-brett/delocate/issues/135)
+
 * [0.10.1] - 2021-11-23
 
   Bugfix release.

--- a/delocate/pkginfo.py
+++ b/delocate/pkginfo.py
@@ -1,0 +1,29 @@
+"""Tools for reading and writing PKG-INFO / METADATA without caring
+about the encoding.
+
+This is based on a copy of the old wheel.pkginfo module.
+"""
+from email.generator import Generator
+from email.message import Message
+from email.parser import Parser
+from os import PathLike
+from typing import Union
+
+
+def read_pkg_info_bytes(bytestr: Union[bytes, str]) -> Message:
+    """Parse a PKG-INFO or METADATA data string."""
+    if isinstance(bytestr, bytes):
+        bytestr = bytestr.decode("utf-8")
+    return Parser().parsestr(bytestr)
+
+
+def read_pkg_info(path: Union[bytes, str, PathLike]) -> Message:
+    """Read a PKG-INFO or METADATA file."""
+    with open(path, encoding="utf-8") as headers:
+        return Parser().parse(headers)
+
+
+def write_pkg_info(path: Union[bytes, str, PathLike], message: Message) -> None:
+    """Write to a PKG-INFO or METADATA file."""
+    with open(path, "w", encoding="utf-8") as out:
+        Generator(out, mangle_from_=False, maxheaderlen=0).flatten(message)

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -3,15 +3,14 @@
 
 import os
 import shutil
+from email.message import Message
 from os.path import basename, exists, isfile
 from os.path import join as pjoin
 from os.path import realpath, splitext
 from typing import AnyStr
 
-try:
-    from wheel.install import WheelFile
-except ImportError:  # As of Wheel 0.32.0
-    from wheel.wheelfile import WheelFile
+from delocate.pkginfo import read_pkg_info_bytes
+from wheel.wheelfile import WheelFile
 
 from ..tmpdirs import InTemporaryDirectory
 from ..tools import open_readable, zip2dir
@@ -119,15 +118,7 @@ def _filter_key(items, key):
     return [(k, v) for k, v in items if k != key]
 
 
-def get_info(wheelfile):
-    # Work round wheel API changes
-    try:
-        return wheelfile.parsed_wheel_info
-    except AttributeError:
-        pass
-    # Wheel 0.32.0
-    from wheel.pkginfo import read_pkg_info_bytes
-
+def get_info(wheelfile: WheelFile) -> Message:
     info_name = _get_wheelinfo_name(wheelfile)
     return read_pkg_info_bytes(wheelfile.read(info_name))
 

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -15,13 +15,9 @@ from os.path import relpath
 from os.path import sep as psep
 from os.path import splitext
 
-from wheel.pkginfo import read_pkg_info, write_pkg_info
+from delocate.pkginfo import read_pkg_info, write_pkg_info
 from wheel.util import native, urlsafe_b64encode
-
-try:
-    from wheel.install import WheelFile
-except ImportError:  # As of Wheel 0.32.0
-    from wheel.wheelfile import WheelFile
+from wheel.wheelfile import WheelFile
 
 from .tmpdirs import InTemporaryDirectory
 from .tools import dir2zip, open_rw, unique_by_index, zip2dir
@@ -158,12 +154,8 @@ class InWheelCtx(InWheel):
         return self
 
 
-def _get_wheelinfo_name(wheelfile):
-    # Work round wheel API compatibility
-    try:
-        return wheelfile.wheelinfo_name
-    except AttributeError:
-        return wheelfile.dist_info_path + "/WHEEL"
+def _get_wheelinfo_name(wheelfile: WheelFile):
+    return wheelfile.dist_info_path + "/WHEEL"
 
 
 def add_platforms(in_wheel, platforms, out_path=None, clobber=False):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "machomachomangler; sys_platform == 'win32'",
         "bindepend; sys_platform == 'win32'",
-        "wheel",
+        "wheel>=0.32.0",
         "typing_extensions",
     ],
     package_data={


### PR DESCRIPTION
The plans to remove the `wheel.pkginfo` module can be negotiated with the `wheel` devs, but this PR should cause less drama.

Adds `delocate.pkginfo` to read/write these files, based on the original module.

Removes code supporting `wheel<0.32.0`.  Adds code to support the unreleased versions of `wheel>0.37.1`.

Adds type hinting to the relevant functions.

Closes #135 