### PR TITLE
Remove dependencies on wheels unstable API.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,6 +53,14 @@ jobs:
             dist/delocate-*.whl
           retention-days: 3
           if-no-files-found: error
+      - name: Upload requirements
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-requirements
+          path: |
+            test-requirements.txt
+          retention-days: 3
+          if-no-files-found: error
       - name: Run tests
         run: |
           pytest
@@ -92,9 +100,13 @@ jobs:
       - name: Install delocate
         run: |
           pip install delocate-*.whl
+      - name: Download requirements
+        uses: actions/download-artifact@v2
+        with:
+          name: test-requirements
       - name: Install test dependencies
         run: |
-          pip install pytest
+          pip install -r test-requirements.txt
       - name: Run isolated tests
         run: |
           pytest --pyargs delocate --log-level DEBUG --doctest-modules

--- a/Changelog
+++ b/Changelog
@@ -22,6 +22,7 @@ Releases
 * [Unreleased]
 
   * Support for Python 3.6 has been dropped.
+  * Delocate no longer depends on the ``wheel`` API.
 
 * [0.10.2] - 2021-12-31
 

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -16,6 +16,8 @@ from os.path import join as pjoin
 from os.path import realpath, splitext
 from typing import Text
 
+import pytest
+
 from ..tmpdirs import InGivenDirectory, InTemporaryDirectory
 from ..tools import dir2zip, set_install_name, zip2dir
 from ..wheeltools import InWheel
@@ -426,32 +428,28 @@ def test_patch_wheel():
         )
 
 
-def test_add_platforms():
+def test_add_platforms() -> None:
     # Check adding platform to wheel name and tag section
     assert_winfo_similar(PLAT_WHEEL, EXP_ITEMS, drop_version=False)
     with InTemporaryDirectory() as tmpdir:
         # First wheel needs proper wheel filename for later unpack test
         out_fname = basename(PURE_WHEEL)
         # Need to specify at least one platform
-        assert_raises(
-            RuntimeError,
-            run_command,
-            ["delocate-addplat", PURE_WHEEL, "-w", tmpdir],
-        )
+        with pytest.raises(RuntimeError):
+            run_command(["delocate-addplat", PURE_WHEEL, "-w", tmpdir])
         plat_args = ["-p", EXTRA_PLATS[0], "--plat-tag", EXTRA_PLATS[1]]
         # Can't add platforms to a pure wheel
-        assert_raises(
-            RuntimeError,
-            run_command,
-            ["delocate-addplat", PURE_WHEEL, "-w", tmpdir] + plat_args,
-        )
-        assert_false(exists(out_fname))
+        with pytest.raises(RuntimeError):
+            run_command(
+                ["delocate-addplat", PURE_WHEEL, "-w", tmpdir] + plat_args
+            )
+        assert not exists(out_fname)
         # Error raised (as above) unless ``--skip-error`` flag set
         code, stdout, stderr = run_command(
             ["delocate-addplat", PURE_WHEEL, "-w", tmpdir, "-k"] + plat_args
         )
         # Still doesn't do anything though
-        assert_false(exists(out_fname))
+        assert not exists(out_fname)
         # Works for plat_wheel
         out_fname = ".".join(
             (splitext(basename(PLAT_WHEEL))[0],) + EXTRA_PLATS + ("whl",)
@@ -459,14 +457,13 @@ def test_add_platforms():
         code, stdout, stderr = run_command(
             ["delocate-addplat", PLAT_WHEEL, "-w", tmpdir] + plat_args
         )
-        assert_true(isfile(out_fname))
+        assert isfile(out_fname)
         assert_winfo_similar(out_fname, EXTRA_EXPS)
         # If wheel exists (as it does) then raise error
-        assert_raises(
-            RuntimeError,
-            run_command,
-            ["delocate-addplat", PLAT_WHEEL, "-w", tmpdir] + plat_args,
-        )
+        with pytest.raises(RuntimeError):
+            run_command(
+                ["delocate-addplat", PLAT_WHEEL, "-w", tmpdir] + plat_args
+            )
         # Unless clobber is set
         code, stdout, stderr = run_command(
             ["delocate-addplat", PLAT_WHEEL, "-c", "-w", tmpdir] + plat_args
@@ -509,14 +506,14 @@ def test_add_platforms():
         code, stdout, stderr = run_command(
             ["delocate-addplat", local_plat] + plat_args
         )
-        assert_true(exists(local_out))
+        assert exists(local_out)
         # With rm_orig flag, delete original unmodified wheel
         os.unlink(local_out)
         code, stdout, stderr = run_command(
             ["delocate-addplat", "-r", local_plat] + plat_args
         )
-        assert_false(exists(local_plat))
-        assert_true(exists(local_out))
+        assert not exists(local_plat)
+        assert exists(local_out)
         # Copy original back again
         shutil.copy2(PLAT_WHEEL, "wheels")
         # If platforms already present, don't write more
@@ -525,20 +522,19 @@ def test_add_platforms():
         code, stdout, stderr = run_command(
             ["delocate-addplat", local_out, "--clobber"] + plat_args
         )
-        assert_equal(sorted(os.listdir("wheels")), res)
+        assert sorted(os.listdir("wheels")) == res
         assert_winfo_similar(local_out, EXTRA_EXPS)
         # The wheel doesn't get deleted output name same as input, as here
         code, stdout, stderr = run_command(
             ["delocate-addplat", local_out, "-r", "--clobber"] + plat_args
         )
-        assert_equal(sorted(os.listdir("wheels")), res)
+        assert sorted(os.listdir("wheels")) == res
         # But adds WHEEL tags if missing, even if file name is OK
         shutil.copy2(local_plat, local_out)
-        assert_raises(
-            AssertionError, assert_winfo_similar, local_out, EXTRA_EXPS
-        )
+        with pytest.raises(AssertionError):
+            assert_winfo_similar(local_out, EXTRA_EXPS)
         code, stdout, stderr = run_command(
             ["delocate-addplat", local_out, "--clobber"] + plat_args
         )
-        assert_equal(sorted(os.listdir("wheels")), res)
+        assert sorted(os.listdir("wheels")) == res
         assert_winfo_similar(local_out, EXTRA_EXPS)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "machomachomangler; sys_platform == 'win32'",
         "bindepend; sys_platform == 'win32'",
-        "packaging",
+        "packaging>=20.9",
         "typing_extensions",
     ],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     install_requires=[
         "machomachomangler; sys_platform == 'win32'",
         "bindepend; sys_platform == 'win32'",
-        "wheel>=0.32.0",
+        "packaging",
         "typing_extensions",
     ],
     package_data={


### PR DESCRIPTION
Based on feedback from https://github.com/pypa/wheel/issues/433.  There are plans on refactoring wheel which will likely break Delocate again.  This PR will prevent that from happening.

Small single-used wheel functions are now inline.  The packaging module was added which has a stable API for parsing wheel names.  Type hinting added to relevant functions.