### PR TITLE
Drop Python 3.6.

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.6
+python_version = 3.7
 
 [mypy-wheel.*]
 ignore_missing_imports = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 matrix:
   include:
-      - env: MB_PYTHON_VERSION=3.6
       - env: MB_PYTHON_VERSION=3.8
       - env: MB_PYTHON_VERSION=3.9
         env:

--- a/Changelog
+++ b/Changelog
@@ -21,6 +21,8 @@ Releases
 
 * [Unreleased]
 
+  * Support for Python 3.6 has been dropped.
+
 * [0.10.2] - 2021-12-31
 
   Bugfix and compatibility release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.black]
 line-length = 80
-target-version = ['py36']
+target-version = ['py37']
 extend-exclude = '''versioneer.py|delocate/_version.py'''
 experimental-string-processing = true
 
 [tool.isort]
 profile = "black"
-py_version = 36
+py_version = 37
 src_paths = ["isort", "test"]
 line_length = 80
 extend_skip = ["versioneer.py", "delocate/_version.py"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email="matthew.brett@gmail.com",
     url="http://github.com/matthew-brett/delocate",
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "machomachomangler; sys_platform == 'win32'",
         "bindepend; sys_platform == 'win32'",

--- a/wheel_makers/make_wheels.sh
+++ b/wheel_makers/make_wheels.sh
@@ -13,7 +13,7 @@ rm -f */libs/*.dylib
 rm -f */MANIFEST
 
 cd fakepkg1
-python setup.py clean bdist_wheel --py-limited-api=cp36
+python setup.py clean bdist_wheel --py-limited-api=cp37
 cd -
 
 cd fakepkg2
@@ -21,15 +21,15 @@ python setup.py clean bdist_wheel
 cd -
 
 cd fakepkg_rpath
-python setup.py clean bdist_wheel --py-limited-api=cp36
+python setup.py clean bdist_wheel --py-limited-api=cp37
 cd -
 
 cd fakepkg_toplevel
-python setup.py clean bdist_wheel --py-limited-api=cp36
+python setup.py clean bdist_wheel --py-limited-api=cp37
 cd -
 
 cd fakepkg_namespace
-python setup.py clean bdist_wheel --py-limited-api=cp36
+python setup.py clean bdist_wheel --py-limited-api=cp37
 cd -
 
 OUT_PATH=../delocate/tests/data


### PR DESCRIPTION
Python 3.6 has reached end-of-life: https://endoflife.date/python

Python 3.7 has postponed evaluations of annotations which I'd like to start using: https://docs.python.org/3/whatsnew/3.7.html