### PR TITLE
Use future annotations.

### DIFF
--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -1,4 +1,6 @@
 """ Tools for getting and setting install names """
+from __future__ import annotations
+
 import os
 import re
 import stat


### PR DESCRIPTION
The previous merges caused a logical conflict.

Since Python 3.7 is now the lowest version, type hints can now be deferred outside of runtime.  This fixes the error with `subprocess.CompletedProcess[str]` which is not available at runtime on older Python versions.

I'm merging this as soon as tests pass.