### PR TITLE
Remove always True function check.

### DIFF
--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -314,7 +314,7 @@ def _tree_libs_from_libraries(
             if depending_path is None:
                 missing_libs = True
                 continue
-            if copy_filt_func and not copy_filt_func(depending_path):
+            if not copy_filt_func(depending_path):
                 continue
             lib_dict.setdefault(depending_path, {})
             lib_dict[depending_path][library_path] = install_name


### PR DESCRIPTION
A new version of Mypy detected this issue, and will raise errors until it's fixed.
This code was copied from other places. It's intended that this isn't an optional function here, so I'm removing the extra check.