### PR TITLE
Speed-up delocate on large wheels.

### DIFF
--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -401,10 +401,11 @@ cmdsize 0
 )
 def test_names_multi(arch_def: ToolArchMock) -> None:
     with mock.patch("subprocess.run", arch_def.mock_subprocess_run):
-        with assert_raises_if_exception(arch_def.expected_install_names):
-            assert (
-                get_install_names("example.so")
-                == arch_def.expected_install_names
-            )
-        with assert_raises_if_exception(arch_def.expected_rpaths):
-            assert get_rpaths("example.so") == arch_def.expected_rpaths
+        with mock.patch("delocate.tools._is_macho_file", return_value=True):
+            with assert_raises_if_exception(arch_def.expected_install_names):
+                assert (
+                    get_install_names("example.so")
+                    == arch_def.expected_install_names
+                )
+            with assert_raises_if_exception(arch_def.expected_rpaths):
+                assert get_rpaths("example.so") == arch_def.expected_rpaths

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -13,6 +13,7 @@ import pytest
 
 from ..tmpdirs import InTemporaryDirectory
 from ..tools import (
+    _is_macho_file,
     add_rpath,
     back_tick,
     chmod_perms,
@@ -325,3 +326,17 @@ def test_validate_signature() -> None:
         )
         with pytest.raises(subprocess.CalledProcessError):
             check_signature("libcopy")
+
+
+def test_is_macho_file() -> None:
+    MACHO_FILES = frozenset(
+        filename
+        for filename in os.listdir(DATA_PATH)
+        if filename.endswith((".o", ".dylib", ".so", "test-lib"))
+    )
+
+    for filename in os.listdir(DATA_PATH):
+        path = pjoin(DATA_PATH, filename)
+        if not os.path.isfile(path):
+            continue
+        assert_equal(_is_macho_file(path), filename in MACHO_FILES)

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -162,7 +162,7 @@ MACHO_MAGIC = (
 
 
 def _is_macho_file(filename: str) -> bool:
-    """Return True if the file at `filename` begins with a Mach-O magic number."""
+    """Return True if file at `filename` begins with Mach-O magic number."""
     try:
         with open(filename, "rb") as f:
             header = f.read(4)

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -148,6 +148,30 @@ def _run(
         ) from exc
 
 
+# Mach-O magic numbers. See:
+# https://github.com/apple-oss-distributions/xnu/blob/5c2921b07a2480ab43ec66f5b9e41cb872bc554f/EXTERNAL_HEADERS/mach-o/loader.h#L65
+# https://github.com/apple-oss-distributions/cctools/blob/658da8c66b4e184458f9c810deca9f6428a773a5/include/mach-o/fat.h#L48
+MACHO_MAGIC = (
+    0xFEEDFACE.to_bytes(4, "little"),  # MH_MAGIC
+    0xFEEDFACE.to_bytes(4, "big"),  # MH_MAGIC
+    0xFEEDFACF.to_bytes(4, "little"),  # MH_MAGIC_64
+    0xFEEDFACF.to_bytes(4, "big"),  # MH_MAGIC_64
+    0xCAFEBABE.to_bytes(4, "big"),  # FAT_MAGIC (always big-endian)
+    0xCAFEBABF.to_bytes(4, "big"),  # FAT_MAGIC_64 (always big-endian)
+)
+
+
+def _is_macho_file(filename: str) -> bool:
+    try:
+        with open(filename, "rb") as f:
+            header = f.read(4)
+            return header in MACHO_MAGIC
+    except PermissionError:
+        return False
+    except FileNotFoundError:
+        return False
+
+
 def unique_by_index(sequence):
     """unique elements in `sequence` in the order in which they occur
 
@@ -514,6 +538,8 @@ def get_install_names(filename: str) -> Tuple[str, ...]:
     InstallNameError
         On any unexpected output from ``otool``.
     """
+    if not _is_macho_file(filename):
+        return ()
     otool = _run(["otool", "-L", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()
@@ -576,6 +602,8 @@ def _get_install_ids(filename: str) -> Dict[str, str]:
     InstallNameError
         On any unexpected output from ``otool``.
     """
+    if not _is_macho_file(filename):
+        return {}
     otool = _run(["otool", "-D", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return {}
@@ -730,6 +758,8 @@ def get_rpaths(filename: str) -> Tuple[str, ...]:
     InstallNameError
         On any unexpected output from ``otool``.
     """
+    if not _is_macho_file(filename):
+        return ()
     otool = _run(["otool", "-l", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -151,13 +151,15 @@ def _run(
 # Mach-O magic numbers. See:
 # https://github.com/apple-oss-distributions/xnu/blob/5c2921b07a2480ab43ec66f5b9e41cb872bc554f/EXTERNAL_HEADERS/mach-o/loader.h#L65
 # https://github.com/apple-oss-distributions/cctools/blob/658da8c66b4e184458f9c810deca9f6428a773a5/include/mach-o/fat.h#L48
-MACHO_MAGIC = (
-    0xFEEDFACE.to_bytes(4, "little"),  # MH_MAGIC
-    0xFEEDFACE.to_bytes(4, "big"),  # MH_MAGIC
-    0xFEEDFACF.to_bytes(4, "little"),  # MH_MAGIC_64
-    0xFEEDFACF.to_bytes(4, "big"),  # MH_MAGIC_64
-    0xCAFEBABE.to_bytes(4, "big"),  # FAT_MAGIC (always big-endian)
-    0xCAFEBABF.to_bytes(4, "big"),  # FAT_MAGIC_64 (always big-endian)
+MACHO_MAGIC = frozenset(
+    [
+        0xFEEDFACE.to_bytes(4, "little"),  # MH_MAGIC
+        0xFEEDFACE.to_bytes(4, "big"),  # MH_MAGIC
+        0xFEEDFACF.to_bytes(4, "little"),  # MH_MAGIC_64
+        0xFEEDFACF.to_bytes(4, "big"),  # MH_MAGIC_64
+        0xCAFEBABE.to_bytes(4, "big"),  # FAT_MAGIC (always big-endian)
+        0xCAFEBABF.to_bytes(4, "big"),  # FAT_MAGIC_64 (always big-endian)
+    ]
 )
 
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -162,6 +162,7 @@ MACHO_MAGIC = (
 
 
 def _is_macho_file(filename: str) -> bool:
+    """Return True if the file at `filename` begins with a Mach-O magic number."""
     try:
         with open(filename, "rb") as f:
             header = f.read(4)


### PR DESCRIPTION
Mach-O executables and libraries begin with a magic number. It's much faster to read the first few bytes of a file than to spawn `otool`.

For example, `delocate list-deps` currently takes about 12 minutes on the PyTorch macOS wheels (and nearly twice as long on GitHub's CI runners). With this change, `delocate list-deps` instead takes about 40 seconds.