### PR TITLE
Suppress filename output in unzip call.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
         run: isort . --check --diff
 
   tests:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
         with:
@@ -138,7 +138,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: "macos-10.15"
+          - os: "macos-11"
             xcode: "12.4"
             python: "3.x"
           - os: "macos-11"

--- a/Changelog
+++ b/Changelog
@@ -21,6 +21,8 @@ Releases
 
 * [Unreleased]
 
+ * Fixed `UnicodeDecodeError` when an archive has non-ASCII characters.
+
 * [0.10.4] - 2022-12-17
 
   * Dependency paths with ``@rpath``, ``@loader_path`` and ``@executable_path``

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -791,7 +791,7 @@ def zip2dir(zip_fname: str, out_dir: str) -> None:
     """
     # Use unzip command rather than zipfile module to preserve permissions
     # http://bugs.python.org/issue15795
-    _run(["unzip", "-o", "-d", out_dir, zip_fname], check=True)
+    _run(["unzip", "-q", "-o", "-d", out_dir, zip_fname], check=True)
 
 
 def dir2zip(in_dir, zip_fname):


### PR DESCRIPTION
The `unzip` command on MacOS does not seem to handle Python's UTF-8 locale correctly. Running `unzip -q` should skip outputting these non-ASCII filenames in otherwise working runs.

In theory this change may also improve the performance of large archives.

Fixes #181