### PR TITLE
Refactor zip functions.

### DIFF
--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -173,7 +173,7 @@ def _write_file(filename, contents):
         fobj.write(contents)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Tests Unix permissions")
 def test_zip2() -> None:
     # Test utilities to unzip and zip up
     with InTemporaryDirectory():

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -68,7 +68,6 @@ class PlatWheel(NamedTuple):
     stray_lib: str  # Path to the external library.
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.")
 @pytest.mark.xfail(sys.platform != "darwin", reason="otool")
 def test_fix_pure_python():
     # Test fixing a pure python package gives no change
@@ -228,7 +227,6 @@ def _thin_mod(wheel, arch):
         check_call(["lipo", "-thin", arch, mod_fname, "-output", mod_fname])
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.")
 @pytest.mark.xfail(sys.platform != "darwin", reason="otool")
 def test__thinning():
     with InTemporaryDirectory() as tmpdir:
@@ -309,7 +307,6 @@ def test_check_plat_archs():
         )
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.", strict=False)
 def test_patch_wheel() -> None:
     # Check patching of wheel
     with InTemporaryDirectory():

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -4,7 +4,6 @@
 import os
 import re
 import shutil
-import sys
 from email.message import Message
 from os.path import basename, exists, isfile
 from os.path import join as pjoin
@@ -59,7 +58,6 @@ def assert_record_equal(record_orig: AnyStr, record_new: AnyStr) -> None:
     assert sorted(record_orig.splitlines()) == sorted(record_new.splitlines())
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.", strict=False)
 def test_rewrite_record():
     dist_info_sdir = "fakepkg2-1.0.dist-info"
     with InTemporaryDirectory():
@@ -90,7 +88,6 @@ def test_rewrite_record():
         assert_raises(WheelToolsError, rewrite_record, "wheel")
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.", strict=False)
 def test_in_wheel():
     # Test in-wheel context managers
     # Stuff they share
@@ -162,7 +159,6 @@ def assert_winfo_similar(
         assert value1 == value2
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Needs unzip.")
 def test_add_platforms() -> None:
     # Check adding platform to wheel name and tag section
     assert_winfo_similar(PLAT_WHEEL, EXP_ITEMS, drop_version=False)


### PR DESCRIPTION
It was suggested [here](https://github.com/matthew-brett/delocate/issues/181#issuecomment-1544388928) to port the zip functions from auditwheel.
Changes were made to fit Delocate's test conditions and use-cases and to clean up these functions.

Calls to the `unzip` command were removed, Windows can now test these functions.