### PR TITLE
Move console scripts to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ classifiers = [
     "Typing :: Typed",
 ]
 
+[project.scripts]
+delocate-addplat = "delocate.cmd.delocate_addplat:main"
+delocate-fuse = "delocate.cmd.delocate_fuse:main"
+delocate-listdeps = "delocate.cmd.delocate_listdeps:main"
+delocate-patch = "delocate.cmd.delocate_patch:main"
+delocate-path = "delocate.cmd.delocate_path:main"
+delocate-wheel = "delocate.cmd.delocate_wheel:main"
+
 [project.urls]
 Homepage = "http://github.com/matthew-brett/delocate"
 

--- a/setup.py
+++ b/setup.py
@@ -22,17 +22,4 @@ setup(
         ],
         "delocate": ["py.typed"],
     },
-    entry_points={
-        "console_scripts": [
-            f"delocate-{name} = delocate.cmd.delocate_{name}:main"
-            for name in (
-                "addplat",
-                "fuse",
-                "listdeps",
-                "patch",
-                "path",
-                "wheel",
-            )
-        ]
-    },
 )


### PR DESCRIPTION
I didn't notice to set scripts as dynamic in pyproject.toml when I first set it up. This caused deprecated behavior which recently caused the scripts to go missing during tests and in general. This issue shouldn't affect installs from wheels, only manual installs.

I moved all scripts to pyproject.toml as that's more portable and will reduce reliance on setup.py.