### PR TITLE
Replace black/isort/flake8 with Ruff and pre-commit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 80
-per-file-ignores =
-    delocate/tmpdirs.py: E266
-select = E,F,W
-ignore = W503,W504,E203
-exclude = delocate/_version.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,21 +10,14 @@ defaults:
     shell: bash
 
 jobs:
-  flake8:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
-      - name: Install Flake8
-        run: |
-          pip install flake8
-      - name: Run Flake8
-        uses: liskin/gh-problem-matcher-wrap@v2
-        with:
-          linters: flake8
-          run: flake8 .
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.0
 
   mypy:
     runs-on: ubuntu-latest
@@ -46,25 +39,8 @@ jobs:
           linters: mypy
           run: mypy --show-column-numbers delocate/
 
-  black:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Black
-        run: pip install black
-      - name: Run black
-        run: black . --check --diff
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install isort
-        run: pip install isort
-      - name: Run isort
-        run: isort . --check --diff
-
   tests:
+    needs: [pre-commit, mypy]
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.5
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+default_language_version:
+  python: python3.12

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,12 +4,14 @@
     ],
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.fixAll": true,
+    },
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,
     "files.insertFinalNewline": true,
-    "python.formatting.provider": "black",
     "python.testing.pytestArgs": [],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+This project uses [pre-commit](https://pre-commit.com/) hooks.
+You should install these hooks by running the following commands from the project directory:
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+Installing IDE plugins supporting [Mypy](https://mypy.readthedocs.io/en/stable/) and [Ruff](https://docs.astral.sh/ruff/) is recommend.
+
+Documentation follows the [Numpydoc Style Guide](https://numpydoc.readthedocs.io/en/latest/format.html).
+
+The `wheel_makers` directory holds scripts used to make test data. GitHub Actions will generate this data and upload it as an artifact named `delocate-tests-data`. This can be used to create and commit new test wheels for MacOS even if you don't have access to your own system.

--- a/delocate/cmd/common.py
+++ b/delocate/cmd/common.py
@@ -10,8 +10,9 @@ import sys
 from optparse import Option, OptionParser, Values
 from typing import Callable, List
 
-from delocate.delocating import filter_system_libs
 from typing_extensions import Literal, TypedDict
+
+from delocate.delocating import filter_system_libs
 
 logger = logging.getLogger(__name__)
 

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ Add platform tags to wheel filename(s) and WHEEL file in wheel
 
 Example:

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -19,9 +19,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 from optparse import Option, OptionParser
-from os.path import expanduser
+from os.path import expanduser, realpath
 from os.path import join as exists
-from os.path import realpath
 
 from delocate import __version__
 from delocate.cmd.common import verbosity_args, verbosity_config

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ Fuse two (probably delocated) wheels
 
 Overwrites the first wheel in-place by default

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ List library dependencies for libraries in path or wheel
 """
 # vim: ft=python

--- a/delocate/cmd/delocate_patch.py
+++ b/delocate/cmd/delocate_patch.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ Apply patch to tree stored in wheel
 
 Overwrites the wheel in-place by default

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ Copy, relink library dependencies for libraries in path
 """
 # vim: ft=python

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 """ Copy, relink library dependencies for wheel
 
 Overwrites the wheel in-place by default

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -8,9 +8,8 @@ import logging
 import os
 import shutil
 import warnings
-from os.path import abspath, basename, dirname, exists
+from os.path import abspath, basename, dirname, exists, realpath, relpath
 from os.path import join as pjoin
-from os.path import realpath, relpath
 from subprocess import PIPE, Popen
 from typing import (
     Callable,

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -15,9 +15,8 @@ libraries.
 
 import os
 import shutil
-from os.path import abspath, exists
+from os.path import abspath, exists, relpath, splitext
 from os.path import join as pjoin
-from os.path import relpath, splitext
 
 from .tmpdirs import InTemporaryDirectory
 from .tools import (

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -7,9 +7,8 @@ import logging
 import os
 import sys
 import warnings
-from os.path import basename, dirname
+from os.path import basename, dirname, realpath
 from os.path import join as pjoin
-from os.path import realpath
 from typing import (
     Callable,
     Dict,
@@ -427,7 +426,7 @@ def tree_libs(
 
     See:
 
-    * https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/dyld.1.html  # noqa: E501
+    * https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/dyld.1.html
     * http://matthew-brett.github.io/pydagogue/mac_runtime_link.html
 
     .. deprecated:: 0.9

--- a/delocate/tests/conftest.py
+++ b/delocate/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+
 from delocate.tools import set_install_name
 from delocate.wheeltools import InWheelCtx
 

--- a/delocate/tests/data/fakepkg2.bad_patch
+++ b/delocate/tests/data/fakepkg2.bad_patch
@@ -4,7 +4,7 @@ index 0f2d010..3837ceb 100644
 +++ b/fakepkg2/module1.py
 @@ -1,4 +1,4 @@
  """ First module """
- 
+
  def func1():
 -    return 3
 +    return 2

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -7,9 +7,8 @@ import shutil
 import subprocess
 import sys
 from collections import namedtuple
-from os.path import basename, dirname
+from os.path import basename, dirname, realpath, relpath, splitext
 from os.path import join as pjoin
-from os.path import realpath, relpath, splitext
 from typing import Any, Callable, Dict, Iterable, List, Set, Text, Tuple
 
 import pytest

--- a/delocate/tests/test_fuse.py
+++ b/delocate/tests/test_fuse.py
@@ -5,9 +5,8 @@ import os
 import shutil
 import subprocess
 import sys
-from os.path import basename, dirname, isdir
+from os.path import basename, dirname, isdir, relpath
 from os.path import join as pjoin
-from os.path import relpath
 
 import pytest
 

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -7,9 +7,8 @@ import os
 import shutil
 import subprocess
 import sys
-from os.path import dirname
+from os.path import dirname, realpath, relpath, split
 from os.path import join as pjoin
-from os.path import realpath, relpath, split
 from typing import Dict, Iterable, Text
 from unittest import mock
 

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -12,9 +12,8 @@ import os
 import shutil
 import subprocess
 import sys
-from os.path import basename, exists
+from os.path import basename, exists, realpath, splitext
 from os.path import join as pjoin
-from os.path import realpath, splitext
 from pathlib import Path
 from typing import Text
 

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -8,9 +8,8 @@ import subprocess
 import sys
 import zipfile
 from glob import glob
-from os.path import abspath, basename, exists, isdir
+from os.path import abspath, basename, exists, isdir, realpath
 from os.path import join as pjoin
-from os.path import realpath
 from pathlib import Path
 from subprocess import check_call
 from typing import NamedTuple

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -5,15 +5,15 @@ import os
 import re
 import shutil
 from email.message import Message
-from os.path import basename, exists, isfile
+from os.path import basename, exists, isfile, realpath, splitext
 from os.path import join as pjoin
-from os.path import realpath, splitext
 from typing import AnyStr, List, Tuple
 from zipfile import ZipFile
 
 import pytest
-from delocate.pkginfo import read_pkg_info_bytes
 from packaging.utils import parse_wheel_filename
+
+from delocate.pkginfo import read_pkg_info_bytes
 
 from ..tmpdirs import InTemporaryDirectory
 from ..tools import open_readable, zip2dir

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -10,15 +10,14 @@ import hashlib
 import os
 import sys
 from itertools import product
-from os.path import abspath, basename, dirname, exists
+from os.path import abspath, basename, dirname, exists, relpath, splitext
 from os.path import join as pjoin
-from os.path import relpath
 from os.path import sep as psep
-from os.path import splitext
 from typing import Iterable, Optional, Union, overload
 
-from delocate.pkginfo import read_pkg_info, write_pkg_info
 from packaging.utils import parse_wheel_filename
+
+from delocate.pkginfo import read_pkg_info, write_pkg_info
 
 from .tmpdirs import InTemporaryDirectory
 from .tools import dir2zip, open_rw, unique_by_index, zip2dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,20 +44,26 @@ Homepage = "http://github.com/matthew-brett/delocate"
 [tool.setuptools_scm]
 write_to = "delocate/_version.py"
 
-[tool.black]
-line-length = 80
-target-version = ['py37']
-extend-exclude = '''delocate/_version.py'''
-
-[tool.isort]
-profile = "black"
-py_version = 37
-src_paths = ["isort", "test"]
-line_length = 80
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 required_plugins = ["pytest-console-scripts>=1.4.0", "pytest-cov"]
 testpaths = ["delocate/"]
 addopts = ["--doctest-modules", "--cov=delocate", "--cov-config=.coveragerc"]
 log_file_level = "DEBUG"
+
+[tool.ruff]
+# https://beta.ruff.rs/docs/rules/
+select = [
+    "E", # pycodestyle
+    "W", # pycodestyle
+    "F", # Pyflakes
+    "I", # isort
+]
+ignore = [
+    "ANN101", # missing-type-self
+    "ANN102", # missing-type-cls
+]
+line-length = 80
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ setup script for delocate package """
 from os.path import join as pjoin
 


### PR DESCRIPTION
This replaces Flake8 and all of the formatting tools I've previously added with Ruff, which includes the features of all the other tools combined while also being fast enough to be used as a pre-commit hook, which I've also setup in this PR.

I've also added a `CONTRIBUTING.md` with everything important I could remember about this project.