### PR TITLE
Use exact directory name to decide dylib files directory

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,11 @@ rules on making a good Changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- No longer picks a random directory when multiple directories end with the
+  package name. [#192](https://github.com/matthew-brett/delocate/issues/192)
+
 ## [0.10.6] - 2023-11-21
 
 ### Added

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -10,6 +10,7 @@ import shutil
 import warnings
 from os.path import abspath, basename, dirname, exists, realpath, relpath
 from os.path import join as pjoin
+from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import (
     Callable,
@@ -531,7 +532,7 @@ def _decide_dylib_bundle_directory(
     """
     package_dirs = find_package_dirs(wheel_dir)
     for directory in package_dirs:
-        if directory.endswith(package_name):
+        if Path(directory).name == package_name:
             # Prefer using the directory with the same name as the package.
             return pjoin(directory, lib_sdir)
     if package_dirs:


### PR DESCRIPTION
Replaces `directory.endswith(package_name)` with the more exact `Path(directory).name == package_name`.

I didn't find any other determinism issues in this function.

I think `find_package_dirs` shouldn't have returned a set, since it operates on `os.listdir` it should've returned a list instead, but that doesn't really matter

Fixes #192