### PR TITLE
Refactor commands to use argparse

### DIFF
--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -6,44 +6,35 @@ Overwrites the first wheel in-place by default
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
 
-import sys
-from optparse import Option, OptionParser
+from argparse import ArgumentParser
 from os.path import abspath, basename, expanduser
 from os.path import join as pjoin
 
-from delocate import __version__
-from delocate.cmd.common import verbosity_args, verbosity_config
+from delocate.cmd.common import common_parser, verbosity_config
 from delocate.fuse import fuse_wheels
+
+parser = ArgumentParser(description=__doc__, parents=[common_parser])
+parser.add_argument(
+    "wheels", nargs=2, metavar="WHEEL", type=str, help="Wheels to fuse"
+)
+parser.add_argument(
+    "-w",
+    "--wheel-dir",
+    action="store",
+    type=str,
+    help="Directory to store delocated wheels"
+    " (default is to overwrite 1st WHEEL input with 2nd)",
+)
 
 
 def main() -> None:
-    parser = OptionParser(
-        usage="%s WHEEL1 WHEEL2\n\n" % sys.argv[0] + __doc__,
-        version="%prog " + __version__,
-    )
-    verbosity_args(parser)
-    parser.add_option(
-        Option(
-            "-w",
-            "--wheel-dir",
-            action="store",
-            type="string",
-            help=(
-                "Directory to store delocated wheels (default is to "
-                "overwrite WHEEL1 input)"
-            ),
-        )
-    )
-    (opts, wheels) = parser.parse_args()
-    verbosity_config(opts)
-    if len(wheels) != 2:
-        parser.print_help()
-        sys.exit(1)
-    wheel1, wheel2 = [abspath(expanduser(wheel)) for wheel in wheels]
-    if opts.wheel_dir is None:
+    args = parser.parse_args()
+    verbosity_config(args)
+    wheel1, wheel2 = [abspath(expanduser(wheel)) for wheel in args.wheels]
+    if args.wheel_dir is None:
         out_wheel = wheel1
     else:
-        out_wheel = pjoin(abspath(expanduser(opts.wheel_dir)), basename(wheel1))
+        out_wheel = pjoin(abspath(expanduser(args.wheel_dir)), basename(wheel1))
     fuse_wheels(wheel1, wheel2, out_wheel)
 
 

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -4,48 +4,44 @@
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
 
-import sys
-from optparse import Option, OptionParser
+from argparse import ArgumentParser
 from os import getcwd
 from os.path import isdir, realpath
 from os.path import sep as psep
 
-from delocate import __version__, wheel_libs
-from delocate.cmd.common import verbosity_args, verbosity_config
+from delocate import wheel_libs
+from delocate.cmd.common import common_parser, verbosity_config
 from delocate.delocating import filter_system_libs
 from delocate.libsana import stripped_lib_dict, tree_libs_from_directory
 
+parser = ArgumentParser(description=__doc__, parents=[common_parser])
+parser.add_argument(
+    "paths",
+    nargs="+",
+    metavar="WHEEL_OR_PATH_TO_ANALYZE",
+    type=str,
+    help="Wheel or directory to check for libraries,"
+    " directories are checked recursively",
+)
+parser.add_argument(
+    "-a",
+    "--all",
+    action="store_true",
+    help="Show all dependencies, including system libs",
+)
+parser.add_argument(
+    "-d",
+    "--depending",
+    action="store_true",
+    help="Show libraries depending on dependencies",
+)
+
 
 def main() -> None:
-    parser = OptionParser(
-        usage="%s WHEEL_OR_PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
-        version="%prog " + __version__,
-    )
-    verbosity_args(parser)
-    parser.add_options(
-        [
-            Option(
-                "-a",
-                "--all",
-                action="store_true",
-                help="Show all dependencies, including system libs",
-            ),
-            Option(
-                "-d",
-                "--depending",
-                action="store_true",
-                help="Show libraries depending on dependencies",
-            ),
-        ]
-    )
-    (opts, paths) = parser.parse_args()
-    verbosity_config(opts)
-    if len(paths) < 1:
-        parser.print_help()
-        sys.exit(1)
-
-    multi = len(paths) > 1
-    for path in paths:
+    args = parser.parse_args()
+    verbosity_config(args)
+    multi = len(args.paths) > 1
+    for path in args.paths:
         if multi:
             print(path + ":")
             indent = "   "
@@ -57,9 +53,9 @@ def main() -> None:
         else:
             lib_dict = wheel_libs(path, ignore_missing=True)
         keys = sorted(lib_dict)
-        if not opts.all:
+        if not args.all:
             keys = [key for key in keys if filter_system_libs(key)]
-        if not opts.depending:
+        if not args.depending:
             if len(keys):
                 print(indent + ("\n" + indent).join(keys))
             continue

--- a/delocate/cmd/delocate_patch.py
+++ b/delocate/cmd/delocate_patch.py
@@ -7,54 +7,47 @@ Overwrites the wheel in-place by default
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
-from optparse import Option, OptionParser
+from argparse import ArgumentParser
 from os.path import basename, exists, expanduser
 from os.path import join as pjoin
 
-from delocate import __version__, patch_wheel
-from delocate.cmd.common import verbosity_args, verbosity_config
+from delocate import patch_wheel
+from delocate.cmd.common import common_parser, verbosity_config
+
+parser = ArgumentParser(description=__doc__, parents=[common_parser])
+parser.add_argument(
+    "wheel", metavar="WHEEL", type=str, help="Wheel file to modify"
+)
+parser.add_argument(
+    "patch_fname", metavar="PATCH", type=str, help="Patch file to apply"
+)
+parser.add_argument(
+    "-w",
+    "--wheel-dir",
+    action="store",
+    type=str,
+    help="Directory to store patched wheel (default is to overwrite input)",
+)
 
 
 def main() -> None:
-    parser = OptionParser(
-        usage="%s WHEEL_FILENAME PATCH_FNAME\n\n" % sys.argv[0] + __doc__,
-        version="%prog " + __version__,
-    )
-    verbosity_args(parser)
-    parser.add_option(
-        Option(
-            "-w",
-            "--wheel-dir",
-            action="store",
-            type="string",
-            help=(
-                "Directory to store patched wheel (default is to "
-                "overwrite input)"
-            ),
-        )
-    )
-    (opts, args) = parser.parse_args()
-    verbosity_config(opts)
-    if len(args) != 2:
-        parser.print_help()
-        sys.exit(1)
-    wheel, patch_fname = args
-    if opts.wheel_dir:
-        wheel_dir = expanduser(opts.wheel_dir)
+    args = parser.parse_args()
+    verbosity_config(args)
+    if args.wheel_dir:
+        wheel_dir = expanduser(args.wheel_dir)
         if not exists(wheel_dir):
             os.makedirs(wheel_dir)
     else:
         wheel_dir = None
-    if opts.verbose:
-        print("Patching: {0} with {1}".format(wheel, patch_fname))
+    if args.verbose:
+        print("Patching: {0} with {1}".format(args.wheel, args.patch_fname))
     if wheel_dir:
-        out_wheel = pjoin(wheel_dir, basename(wheel))
+        out_wheel = pjoin(wheel_dir, basename(args.wheel))
     else:
-        out_wheel = wheel
-    patch_wheel(wheel, patch_fname, out_wheel)
-    if opts.verbose:
-        print("Patched wheel {0} to {1}:".format(wheel, out_wheel))
+        out_wheel = args.wheel
+    patch_wheel(args.wheel, args.patch_fname, out_wheel)
+    if args.verbose:
+        print("Patched wheel {0} to {1}:".format(args.wheel, out_wheel))
 
 
 if __name__ == "__main__":

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -5,54 +5,49 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
-from optparse import Option, OptionParser
+from argparse import ArgumentParser
 
-from delocate import __version__, delocate_path
+from delocate import delocate_path
 from delocate.cmd.common import (
-    delocate_args,
+    common_parser,
+    delocate_parser,
     delocate_values,
-    verbosity_args,
     verbosity_config,
+)
+
+parser = ArgumentParser(
+    description=__doc__, parents=[common_parser, delocate_parser]
+)
+parser.add_argument(
+    "paths",
+    nargs="+",
+    metavar="PATH",
+    type=str,
+    help="Folders to be analyzed and delocated",
+)
+parser.add_argument(
+    "-L",
+    "--lib-path",
+    action="store",
+    default=".dylibs",
+    type=str,
+    help="Output subdirectory path to copy library dependencies",
 )
 
 
 def main() -> None:
-    parser = OptionParser(
-        usage="%s PATH_TO_ANALYZE\n\n" % sys.argv[0] + __doc__,
-        version="%prog " + __version__,
-    )
-    verbosity_args(parser)
-    delocate_args(parser)
-    parser.add_options(
-        [
-            Option(
-                "-L",
-                "--lib-path",
-                action="store",
-                type="string",
-                help="Output subdirectory path to copy library dependencies",
-            ),
-        ]
-    )
-    (opts, paths) = parser.parse_args()
-    verbosity_config(opts)
-    if len(paths) < 1:
-        parser.print_help()
-        sys.exit(1)
-
-    if opts.lib_path is None:
-        opts.lib_path = ".dylibs"
-    multi = len(paths) > 1
-    for path in paths:
+    args = parser.parse_args()
+    verbosity_config(args)
+    multi = len(args.paths) > 1
+    for path in args.paths:
         if multi:
             print(path)
         # evaluate paths relative to the path we are working on
-        lib_path = os.path.join(path, opts.lib_path)
+        lib_path = os.path.join(path, args.lib_path)
         delocate_path(
             path,
             lib_path,
-            **delocate_values(opts),
+            **delocate_values(args),
         )
 
 

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -7,88 +7,81 @@ Overwrites the wheel in-place by default
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
-from optparse import Option, OptionParser
+from argparse import ArgumentParser
 from os.path import basename, exists, expanduser
 from os.path import join as pjoin
 from typing import List, Optional, Text
 
-from delocate import __version__, delocate_wheel
+from delocate import delocate_wheel
 from delocate.cmd.common import (
-    delocate_args,
+    common_parser,
+    delocate_parser,
     delocate_values,
-    verbosity_args,
     verbosity_config,
+)
+
+parser = ArgumentParser(
+    description=__doc__, parents=[common_parser, delocate_parser]
+)
+parser.add_argument(
+    "wheels",
+    nargs="+",
+    metavar="WHEEL",
+    type=str,
+    help="The wheel files to be delocated",
+)
+parser.add_argument(
+    "-L",
+    "--lib-sdir",
+    action="store",
+    type=str,
+    default=".dylibs",
+    help="Subdirectory in packages to store copied libraries",
+)
+parser.add_argument(
+    "-w",
+    "--wheel-dir",
+    action="store",
+    type=str,
+    help="Directory to store delocated wheels (default is to overwrite input)",
+)
+parser.add_argument(
+    "-k",
+    "--check-archs",
+    action="store_true",
+    help="Check architectures of depended libraries",
+)
+parser.add_argument(
+    "--require-archs",
+    metavar="ARCHITECTURES",
+    action="store",
+    type=str,
+    help="Architectures that all wheel libraries should have"
+    " (from 'intel', 'i386', 'x86_64', 'i386,x86_64', 'universal2',"
+    " 'x86_64,arm64')",
 )
 
 
 def main() -> None:
-    parser = OptionParser(
-        usage="%s WHEEL_FILENAME\n\n" % sys.argv[0] + __doc__,
-        version="%prog " + __version__,
-    )
-    verbosity_args(parser)
-    delocate_args(parser)
-    parser.add_options(
-        [
-            Option(
-                "-L",
-                "--lib-sdir",
-                action="store",
-                type="string",
-                default=".dylibs",
-                help="Subdirectory in packages to store copied libraries",
-            ),
-            Option(
-                "-w",
-                "--wheel-dir",
-                action="store",
-                type="string",
-                help=(
-                    "Directory to store delocated wheels (default is to "
-                    "overwrite input)"
-                ),
-            ),
-            Option(
-                "-k",
-                "--check-archs",
-                action="store_true",
-                help="Check architectures of depended libraries",
-            ),
-            Option(
-                "--require-archs",
-                action="store",
-                type="string",
-                help=(
-                    "Architectures that all wheel libraries should "
-                    "have (from 'intel', 'i386', 'x86_64', 'i386,x86_64'"
-                    "'universal2', 'x86_64,arm64')"
-                ),
-            ),
-        ]
-    )
-    (opts, wheels) = parser.parse_args()
-    verbosity_config(opts)
-    if len(wheels) < 1:
-        parser.print_help()
-        sys.exit(1)
-    multi = len(wheels) > 1
-    if opts.wheel_dir:
-        wheel_dir = expanduser(opts.wheel_dir)
+    args = parser.parse_args()
+    verbosity_config(args)
+    multi = len(args.wheels) > 1
+    if args.wheel_dir:
+        wheel_dir = expanduser(args.wheel_dir)
         if not exists(wheel_dir):
             os.makedirs(wheel_dir)
     else:
         wheel_dir = None
     require_archs: Optional[List[Text]] = None
-    if opts.require_archs is None:
-        require_archs = [] if opts.check_archs else None
-    elif "," in opts.require_archs:
-        require_archs = [s.strip() for s in opts.require_archs.split(",")]
+    if args.require_archs is None:
+        require_archs = [] if args.check_archs else None
+    elif "," in args.require_archs:
+        require_archs = [s.strip() for s in args.require_archs.split(",")]
     else:
-        require_archs = opts.require_archs
+        require_archs = args.require_archs
 
-    for wheel in wheels:
-        if multi or opts.verbose:
+    for wheel in args.wheels:
+        if multi or args.verbose:
             print("Fixing: " + wheel)
         if wheel_dir:
             out_wheel = pjoin(wheel_dir, basename(wheel))
@@ -97,12 +90,12 @@ def main() -> None:
         copied = delocate_wheel(
             wheel,
             out_wheel,
-            lib_sdir=opts.lib_sdir,
+            lib_sdir=args.lib_sdir,
             require_archs=require_archs,
-            **delocate_values(opts),
+            **delocate_values(args),
         )
-        if opts.verbose and len(copied):
-            print("Copied to package {0} directory:".format(opts.lib_sdir))
+        if args.verbose and len(copied):
+            print("Copied to package {0} directory:".format(args.lib_sdir))
             copy_lines = ["  " + name for name in sorted(copied)]
             print("\n".join(copy_lines))
 

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -424,7 +424,7 @@ def test_patch_wheel(script_runner: ScriptRunner) -> None:
         shutil.copyfile(PURE_WHEEL, "example.whl")
         # Default is to overwrite input
         script_runner.run(
-            ["delocate-patch", "example.whl", WHEEL_PATCH], check=True
+            ["delocate-patch", "-v", "example.whl", WHEEL_PATCH], check=True
         )
         zip2dir("example.whl", "wheel1")
         assert (


### PR DESCRIPTION
Followed the [upgrade guide](https://docs.python.org/3.12/library/argparse.html#upgrading-optparse-code) on the Python docs.

Now has explicit positional arguments. Moved parser definitions to the top-level to give more room for help strings and parameters and to technically allow debugging of the parser. Shared arguments converted into parser parents. Most redundant code has been moved to the shared module.

I imagine some `help` and `metavar` parameters can still be tuned. I didn't come up with a `help` for every positional argument.

Closes #110