### PR TITLE
Expand globs in simple script arguments

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     ],
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll": true,
+        "source.fixAll": "always"
     },
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff"

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,12 @@ rules on making a good Changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Handle glob paths in more cases for `delocate-wheel`, `delocate-path`,
+  `delocate-listdeps`, and `delocate-addplat`.
+  [#71](https://github.com/matthew-brett/delocate/issues/71)
+
 ### Fixed
 
 - No longer picks a random directory when multiple directories end with the

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -21,7 +21,7 @@ from argparse import ArgumentParser
 from os.path import expanduser, realpath
 from os.path import join as exists
 
-from delocate.cmd.common import common_parser, verbosity_config
+from delocate.cmd.common import common_parser, glob_paths, verbosity_config
 from delocate.wheeltools import WheelToolsError, add_platforms
 
 parser = ArgumentParser(description=__doc__, parents=[common_parser])
@@ -94,7 +94,8 @@ parser.add_argument(
 def main() -> None:
     args = parser.parse_args()
     verbosity_config(args)
-    multi = len(args.wheels) > 1
+    wheels = list(glob_paths(args.wheels))
+    multi = len(wheels) > 1
     if args.wheel_dir:
         wheel_dir = expanduser(args.wheel_dir)
         if not exists(wheel_dir):
@@ -110,7 +111,7 @@ def main() -> None:
             ]
     if len(plat_tags) == 0:
         raise RuntimeError("Need at least one --osx-ver or --plat-tag")
-    for wheel in args.wheels:
+    for wheel in wheels:
         if multi or args.verbose:
             print(
                 "Setting platform tags {0} for wheel {1}".format(

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -10,7 +10,7 @@ from os.path import isdir, realpath
 from os.path import sep as psep
 
 from delocate import wheel_libs
-from delocate.cmd.common import common_parser, verbosity_config
+from delocate.cmd.common import common_parser, glob_paths, verbosity_config
 from delocate.delocating import filter_system_libs
 from delocate.libsana import stripped_lib_dict, tree_libs_from_directory
 
@@ -40,8 +40,9 @@ parser.add_argument(
 def main() -> None:
     args = parser.parse_args()
     verbosity_config(args)
-    multi = len(args.paths) > 1
-    for path in args.paths:
+    paths = list(glob_paths(args.paths))
+    multi = len(paths) > 1
+    for path in paths:
         if multi:
             print(path + ":")
             indent = "   "

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -12,6 +12,7 @@ from delocate.cmd.common import (
     common_parser,
     delocate_parser,
     delocate_values,
+    glob_paths,
     verbosity_config,
 )
 
@@ -38,8 +39,9 @@ parser.add_argument(
 def main() -> None:
     args = parser.parse_args()
     verbosity_config(args)
-    multi = len(args.paths) > 1
-    for path in args.paths:
+    paths = list(glob_paths(args.paths))
+    multi = len(paths) > 1
+    for path in paths:
         if multi:
             print(path)
         # evaluate paths relative to the path we are working on

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -4,7 +4,7 @@
 Overwrites the wheel in-place by default
 """
 # vim: ft=python
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 import os
 from argparse import ArgumentParser
@@ -17,6 +17,7 @@ from delocate.cmd.common import (
     common_parser,
     delocate_parser,
     delocate_values,
+    glob_paths,
     verbosity_config,
 )
 
@@ -65,7 +66,8 @@ parser.add_argument(
 def main() -> None:
     args = parser.parse_args()
     verbosity_config(args)
-    multi = len(args.wheels) > 1
+    wheels = list(glob_paths(args.wheels))
+    multi = len(wheels) > 1
     if args.wheel_dir:
         wheel_dir = expanduser(args.wheel_dir)
         if not exists(wheel_dir):
@@ -80,7 +82,7 @@ def main() -> None:
     else:
         require_archs = args.require_archs
 
-    for wheel in args.wheels:
+    for wheel in wheels:
         if multi or args.verbose:
             print("Fixing: " + wheel)
         if wheel_dir:


### PR DESCRIPTION
Expands globs in simple cases using the following rules:

* If any path is a existing folder or file then it's used as-is, even if it can be used as a glob pattern. This is supposed to ensure that there's no surprises or regressions.
* Otherwise the glob is expanded with Python's `glob` module. If this results in no files then it raises `FileNotFoundError`.

Added tests for this.

Some commands are too complex for this workaround. This only applies to commands which takes one list of arguments and not commands with more complex positional parameters such as `delocate-fuse` and `delocate-patch`.

I'd rather not merge this PR until it's reviewed.

Fixes #71