### PR TITLE
After copying a lib to the wheel directory, set its writeable bit if necessary

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -7,6 +7,7 @@ import functools
 import logging
 import os
 import shutil
+import stat
 import warnings
 from os.path import abspath, basename, dirname, exists, realpath, relpath
 from os.path import join as pjoin
@@ -202,6 +203,11 @@ def _copy_required_libs(
             "Copying library %s to %s", old_path, relpath(new_path, root_path)
         )
         shutil.copy(old_path, new_path)
+        # Make copied file writeable if necessary.
+        statinfo = os.stat(new_path)
+        if not statinfo.st_mode & stat.S_IWRITE:
+            os.chmod(new_path, statinfo.st_mode | stat.S_IWRITE)
+
         # Delocate this file now that it is stored locally.
         needs_delocating.add(new_path)
         # Update out_lib_dict with the new file paths.


### PR DESCRIPTION
Some build systems (e.g., Bazel) generate read-only artifacts, and `shutil.copy` also copies these modes.

Auditwheel has the same logic [here](https://github.com/pypa/auditwheel/blob/db7962149a3e971eba3974a58edcb2226c787f8d/src/auditwheel/repair.py#L160-L162).