### PR TITLE
Use os.pathsep instead of hard coding ':'

### DIFF
--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -767,4 +767,4 @@ def _paths_from_var(varname: str, lib_basename: str) -> List[str]:
     var = os.environ.get(varname)
     if var is None:
         return []
-    return [pjoin(path, lib_basename) for path in var.split(":")]
+    return [pjoin(path, lib_basename) for path in var.split(os.pathsep)]

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -794,7 +794,7 @@ def get_environment_variable_paths():
     for pathname in extra_paths:
         path_contents = os.environ.get(pathname)
         if path_contents is not None:
-            for path in path_contents.split(":"):
+            for path in path_contents.split(os.pathsep):
                 env_var_paths.append(path)
     return tuple(env_var_paths)
 


### PR DESCRIPTION
Don't assume that multi-path environment variables like `DYLD_LIBRARY_PATH` are split by `":"`.
