### PR TITLE
Enable pydocstyle linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,8 @@ repos:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.2.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-default_language_version:
-  python: python3.12

--- a/delocate/__init__.py
+++ b/delocate/__init__.py
@@ -1,4 +1,4 @@
-# Init for delocate package
+"""Delocate package."""
 
 import warnings
 

--- a/delocate/cmd/__init__.py
+++ b/delocate/cmd/__init__.py
@@ -1,0 +1,1 @@
+"""Delocate commands package."""

--- a/delocate/cmd/common.py
+++ b/delocate/cmd/common.py
@@ -1,4 +1,4 @@
-""" Code shared among multiple commands.
+"""Code shared among multiple commands.
 
 All functions in this module are private.
 """
@@ -94,11 +94,10 @@ class DelocateArgs(TypedDict):
 
 def delocate_values(args: Namespace) -> DelocateArgs:
     """Return the common kwargs for delocate_path and delocate_wheel."""
-
     exclude_files: List[str] = args.exclude
 
     def copy_filter_exclude(name: str) -> bool:
-        """Returns False if name is excluded, uses normal rules otherwise."""
+        """Return False if name is excluded, uses normal rules otherwise."""
         for exclude_str in exclude_files:
             if exclude_str in name:
                 logger.info(

--- a/delocate/cmd/delocate_addplat.py
+++ b/delocate/cmd/delocate_addplat.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" Add platform tags to wheel filename(s) and WHEEL file in wheel
+"""Add platform tags to wheel filename(s) and WHEEL file in wheel.
 
 Example:
 
@@ -91,7 +91,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     wheels = list(glob_paths(args.wheels))

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-""" Fuse two (probably delocated) wheels
+"""Fuse two (probably delocated) wheels.
 
-Overwrites the first wheel in-place by default
+Overwrites the first wheel in-place by default.
 """
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
@@ -27,7 +27,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     wheel1, wheel2 = [abspath(expanduser(wheel)) for wheel in args.wheels]

--- a/delocate/cmd/delocate_listdeps.py
+++ b/delocate/cmd/delocate_listdeps.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-""" List library dependencies for libraries in path or wheel
-"""
+"""List library dependencies for libraries in path or wheel."""
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
 
@@ -37,7 +36,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     paths = list(glob_paths(args.paths))

--- a/delocate/cmd/delocate_patch.py
+++ b/delocate/cmd/delocate_patch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-""" Apply patch to tree stored in wheel
+"""Apply patch to tree stored in wheel.
 
-Overwrites the wheel in-place by default
+Overwrites the wheel in-place by default.
 """
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
@@ -30,7 +30,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     if args.wheel_dir:

--- a/delocate/cmd/delocate_path.py
+++ b/delocate/cmd/delocate_path.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-""" Copy, relink library dependencies for libraries in path
-"""
+"""Copy, relink library dependencies for libraries in path."""
 # vim: ft=python
 from __future__ import absolute_import, division, print_function
 
@@ -36,7 +35,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     paths = list(glob_paths(args.paths))

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-""" Copy, relink library dependencies for wheel
+"""Copy, relink library dependencies for wheel.
 
-Overwrites the wheel in-place by default
+Overwrites the wheel in-place by default.
 """
 # vim: ft=python
 from __future__ import annotations
@@ -71,7 +71,7 @@ parser.add_argument(
 )
 
 
-def main() -> None:
+def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     wheels = list(glob_paths(args.wheels))

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -1,5 +1,4 @@
-""" Routines to copy / relink library dependencies in trees and wheels
-"""
+"""Routines to copy / relink library dependencies in trees and wheels."""
 
 from __future__ import annotations
 
@@ -75,7 +74,7 @@ def delocate_tree_libs(
     *,
     sanitize_rpaths: bool = False,
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Move needed libraries in `lib_dict` into `lib_path`
+    """Move needed libraries in `lib_dict` into `lib_path`.
 
     `lib_dict` has keys naming libraries required by the files in the
     corresponding value.  Call the keys, "required libs".  Call the values
@@ -265,7 +264,7 @@ def copy_recurse(
     copy_filt_func: Optional[Callable[[Text], bool]] = None,
     copied_libs: Optional[Dict[Text, Dict[Text, Text]]] = None,
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Analyze `lib_path` for library dependencies and copy libraries
+    """Analyze `lib_path` for library dependencies and copy libraries.
 
     `lib_path` is a directory containing libraries.  The libraries might
     themselves have dependencies.  This function analyzes the dependencies and
@@ -324,7 +323,7 @@ def _copy_required(
     copy_filt_func: Optional[Callable[[Text], bool]],
     copied_libs: Dict[Text, Dict[Text, Text]],
 ) -> None:
-    """Copy libraries required for files in `lib_path` to `copied_libs`
+    """Copy libraries required for files in `lib_path` to `copied_libs`.
 
     Augment `copied_libs` dictionary with any newly copied libraries, modifying
     `copied_libs` in-place - see Notes.
@@ -419,6 +418,7 @@ def _dylibs_only(filename: str) -> bool:
 
 
 def filter_system_libs(libname: str) -> bool:
+    """Return False for system libraries."""
     return not (libname.startswith("/usr/lib") or libname.startswith("/System"))
 
 
@@ -428,8 +428,10 @@ def _delocate_filter_function(
     lib_filt_func: Callable[[str], bool],
     copy_filt_func: Callable[[str], bool],
 ) -> bool:
-    """Combines the library inspection and copy filters so that libraries
-    which won't be copied will not be followed."""
+    """Combine the library inspection and copy filters into one function.
+
+    So that libraries which won't be copied will not be followed.
+    """
     return lib_filt_func(path) and copy_filt_func(path)
 
 
@@ -443,7 +445,7 @@ def delocate_path(
     *,
     sanitize_rpaths: bool = False,
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Copy required libraries for files in `tree_path` into `lib_path`
+    """Copy required libraries for files in `tree_path` into `lib_path`.
 
     Parameters
     ----------
@@ -520,7 +522,7 @@ def delocate_path(
 def _copy_lib_dict(
     lib_dict: Mapping[Text, Mapping[Text, Text]],
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Returns a copy of lib_dict."""
+    """Return a copy of lib_dict."""
     return {  # Convert nested Mapping types into nested Dict types.
         required: dict(requiring) for required, requiring in lib_dict.items()
     }
@@ -630,8 +632,7 @@ def _get_macos_min_version(dylib_path: Path) -> Iterator[tuple[str, Version]]:
 def _get_archs_and_version_from_wheel_name(
     wheel_name: str,
 ) -> dict[str, Version]:
-    """
-    Get the architecture and minimum macOS version from the wheel name.
+    """Get the architecture and minimum macOS version from the wheel name.
 
     Parameters
     ----------
@@ -660,9 +661,7 @@ def _get_problematic_libs(
     version_lib_dict: Dict[Version, List[Path]],
     arch: str,
 ) -> set[tuple[Path, Version]]:
-    """
-    Filter libraries that require more modern macOS
-    version than the provided one.
+    """Find libraries which require a more modern macOS version.
 
     Parameters
     ----------
@@ -703,9 +702,10 @@ def _calculate_minimum_wheel_name(
     wheel_dir: Path,
     require_target_macos_version: Optional[Version],
 ) -> tuple[str, set[tuple[Path, Version]]]:
-    """
-    Update wheel name platform tag, based on the architecture
-    of the libraries in the wheel and actual platform tag.
+    """Return a wheel name with an updated platform tag.
+
+    Based on the architecture of the libraries in the wheel and actual platform
+    tag.
 
     Parameters
     ----------
@@ -811,9 +811,9 @@ def _check_and_update_wheel_name(
     wheel_dir: Path,
     require_target_macos_version: Optional[Version],
 ) -> Path:
-    """
-    Based on curren wheel name and binary files in the wheel,
-    determine the minimum platform tag and update the wheel name if needed.
+    """Determine the minimum platform tag and update the wheel name if needed.
+
+    Based on current wheel name and binary files in the wheel.
 
     Parameters
     ----------
@@ -884,7 +884,7 @@ def delocate_wheel(
     sanitize_rpaths: bool = False,
     require_target_macos_version: Optional[Version] = None,
 ) -> Dict[str, Dict[str, str]]:
-    """Update wheel by copying required libraries to `lib_sdir` in wheel
+    """Update wheel by copying required libraries to `lib_sdir` in wheel.
 
     Create `lib_sdir` in wheel tree only if we are copying one or more
     libraries.
@@ -1018,7 +1018,7 @@ def delocate_wheel(
 def patch_wheel(
     in_wheel: Text, patch_fname: Text, out_wheel: Optional[Text] = None
 ) -> None:
-    """Apply ``-p1`` style patch in `patch_fname` to contents of `in_wheel`
+    """Apply ``-p1`` style patch in `patch_fname` to contents of `in_wheel`.
 
     If `out_wheel` is None (the default), overwrite the wheel `in_wheel`
     in-place.
@@ -1063,7 +1063,7 @@ def check_archs(
 ) -> Set[
     Union[Tuple[Text, FrozenSet[Text]], Tuple[Text, Text, FrozenSet[Text]]]
 ]:
-    """Check compatibility of archs in `copied_libs` dict
+    """Check compatibility of archs in `copied_libs` dict.
 
     Parameters
     ----------
@@ -1127,7 +1127,7 @@ def check_archs(
 
 
 def bads_report(bads, path_prefix=None):
-    """Return a nice report of bad architectures in `bads`
+    """Return a nice report of bad architectures in `bads`.
 
     Parameters
     ----------

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -1,4 +1,4 @@
-""" Utilities to fuse trees and wheels
+"""Utilities to fuse trees and wheels.
 
 To "fuse" is to merge two binary libraries of different architectures - see
 func:`delocate.tools.lipo_fuse`.
@@ -41,7 +41,7 @@ def _copyfile(in_fname, out_fname):
 
 
 def fuse_trees(to_tree, from_tree, lib_exts=(".so", ".dylib", ".a")):
-    """Fuse path `from_tree` into path `to_tree`
+    """Fuse path `from_tree` into path `to_tree`.
 
     For each file in `from_tree` - check for library file extension (in
     `lib_exts` - if present, check if there is a file with matching relative
@@ -50,7 +50,7 @@ def fuse_trees(to_tree, from_tree, lib_exts=(".so", ".dylib", ".a")):
     conditions are not met, just copy the file from `from_tree` to `to_tree`.
 
     Parameters
-    ---------
+    ----------
     to_tree : str
         path of tree to fuse into (update into)
     from_tree : str
@@ -85,10 +85,10 @@ def fuse_trees(to_tree, from_tree, lib_exts=(".so", ".dylib", ".a")):
 
 
 def fuse_wheels(to_wheel, from_wheel, out_wheel):
-    """Fuse `from_wheel` into `to_wheel`, write to `out_wheel`
+    """Fuse `from_wheel` into `to_wheel`, write to `out_wheel`.
 
     Parameters
-    ---------
+    ----------
     to_wheel : str
         filename of wheel to fuse into
     from_wheel : str

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -1,6 +1,6 @@
-""" Analyze libraries in trees
+"""Analyze libraries in trees.
 
-Analyze library dependencies in paths and wheel files
+Analyze library dependencies in paths and wheel files.
 """
 
 import logging
@@ -33,13 +33,11 @@ logger = logging.getLogger(__name__)
 
 
 class DelocationError(Exception):
-    pass
+    """Generic error for when a problem is encountered during delocation."""
 
 
 class DependencyNotFound(Exception):
-    """
-    Raised by tree_libs or resolve_rpath if an expected dependency is missing.
-    """
+    """Raised by tree_libs or resolve_rpath if an expected dependency is missing."""  # noqa: E501
 
 
 def _filter_system_libs(libname: Text) -> bool:
@@ -51,7 +49,7 @@ def get_dependencies(
     executable_path: Optional[Text] = None,
     filt_func: Callable[[str], bool] = lambda filepath: True,
 ) -> Iterator[Tuple[Optional[Text], Text]]:
-    """Find and yield the real paths of dependencies of the library `lib_fname`
+    """Find and yield the real paths of dependencies of the library `lib_fname`.
 
     This function is used to search for the real files that are required by
     `lib_fname`.
@@ -387,7 +385,7 @@ def tree_libs_from_directory(
 
 
 def _allow_all(path: str) -> bool:
-    """A filter which returns True for all files."""
+    """Return True for all files."""
     return True
 
 
@@ -395,7 +393,7 @@ def tree_libs(
     start_path: Text,
     filt_func: Optional[Callable[[Text], bool]] = None,
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Return analysis of library dependencies within `start_path`
+    """Return analysis of library dependencies within `start_path`.
 
     Parameters
     ----------
@@ -405,6 +403,7 @@ def tree_libs(
         If None, inspect all files for library dependencies. If callable,
         accepts filename as argument, returns True if we should inspect the
         file, False otherwise.
+
     Returns
     -------
     lib_dict : dict
@@ -423,7 +422,6 @@ def tree_libs(
 
     Notes
     -----
-
     See:
 
     * https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/dyld.1.html
@@ -544,17 +542,20 @@ def resolve_dynamic_paths(
 
 
 def resolve_rpath(lib_path: Text, rpaths: Iterable[Text]) -> Text:
-    """Return `lib_path` with its `@rpath` resolved
+    """Return `lib_path` with its `@rpath` resolved.
+
     If the `lib_path` doesn't have `@rpath` then it's returned as is.
     If `lib_path` has `@rpath` then returns the first `rpaths`/`lib_path`
     combination found.  If the library can't be found in `rpaths` then a
     detailed warning is printed and `lib_path` is returned as is.
+
     Parameters
     ----------
     lib_path : str
         The path to a library file, which may or may not start with `@rpath`.
     rpaths : sequence of str
         A sequence of search paths, usually gotten from a call to `get_rpaths`.
+
     Returns
     -------
     lib_path : str
@@ -589,7 +590,7 @@ def resolve_rpath(lib_path: Text, rpaths: Iterable[Text]) -> Text:
 
 
 def search_environment_for_lib(lib_path: Text) -> Text:
-    """Search common environment variables for `lib_path`
+    """Search common environment variables for `lib_path`.
 
     We'll use a single approach here:
 
@@ -643,7 +644,7 @@ def search_environment_for_lib(lib_path: Text) -> Text:
 
 
 def get_prefix_stripper(strip_prefix: Text) -> Callable[[Text], Text]:
-    """Return function to strip `strip_prefix` prefix from string if present
+    """Return function to strip `strip_prefix` prefix from string if present.
 
     Parameters
     ----------
@@ -665,7 +666,7 @@ def get_prefix_stripper(strip_prefix: Text) -> Callable[[Text], Text]:
 
 
 def get_rp_stripper(strip_path: Text) -> Callable[[Text], Text]:
-    """Return function to strip ``realpath`` of `strip_path` from string
+    """Return function to strip ``realpath`` of `strip_path` from string.
 
     Parameters
     ----------
@@ -685,7 +686,7 @@ def get_rp_stripper(strip_path: Text) -> Callable[[Text], Text]:
 def stripped_lib_dict(
     lib_dict: Dict[Text, Dict[Text, Text]], strip_prefix: Text
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Return `lib_dict` with `strip_prefix` removed from start of paths
+    """Return `lib_dict` with `strip_prefix` removed from start of paths.
 
     Use to give form of `lib_dict` that appears relative to some base path
     given by `strip_prefix`.  Particularly useful for analyzing wheels where we
@@ -723,7 +724,7 @@ def wheel_libs(
     *,
     ignore_missing: bool = False,
 ) -> Dict[Text, Dict[Text, Text]]:
-    """Return analysis of library dependencies with a Python wheel
+    """Return analysis of library dependencies with a Python wheel.
 
     Use this routine for a dump of the dependency tree.
 

--- a/delocate/pkginfo.py
+++ b/delocate/pkginfo.py
@@ -1,8 +1,7 @@
-"""Tools for reading and writing PKG-INFO / METADATA without caring
-about the encoding.
+"""Tools for reading and writing PKG-INFO / METADATA without caring about the encoding.
 
 This is based on a copy of the old wheel.pkginfo module.
-"""
+"""  # noqa: E501
 from email.generator import Generator
 from email.message import Message
 from email.parser import Parser

--- a/delocate/tests/__init__.py
+++ b/delocate/tests/__init__.py
@@ -1,1 +1,1 @@
-# Make tests a package
+"""Tests package."""

--- a/delocate/tests/conftest.py
+++ b/delocate/tests/conftest.py
@@ -1,3 +1,4 @@
+"""Pytest configuration script."""
 import os
 from pathlib import Path
 from typing import Iterator

--- a/delocate/tests/data/fakepkg2.patch
+++ b/delocate/tests/data/fakepkg2.patch
@@ -2,5 +2,6 @@ diff --git a/fakepkg2/__init__.py b/fakepkg2/__init__.py
 index e69de29..627eba7 100644
 --- a/fakepkg2/__init__.py
 +++ b/fakepkg2/__init__.py
-@@ -0,0 +1 @@
+@@ -1 +1 @@
+-"""Fake package."""
 +print("Am in init")

--- a/delocate/tests/data/some_code.py
+++ b/delocate/tests/data/some_code.py
@@ -1,6 +1,6 @@
-# An example Python code file
+"""An example Python code file."""
 
 
 def func():
-    # Here is my function
+    """Return 1."""
     return 1

--- a/delocate/tests/env_tools.py
+++ b/delocate/tests/env_tools.py
@@ -1,3 +1,4 @@
+"""Context managers for working with environment variables."""
 import os
 from contextlib import contextmanager
 from typing import Iterator
@@ -7,9 +8,7 @@ from ..tmpdirs import InTemporaryDirectory
 
 @contextmanager
 def TempDirWithoutEnvVars(*env_vars):
-    """Remove `env_vars` from the environment and restore them after
-    testing is complete.
-    """
+    """Remove `env_vars` from the environment and restore them after testing is complete."""  # noqa: E501
     old_vars = {}
     for var in env_vars:
         old_vars[var] = os.environ.get(var, None)
@@ -29,9 +28,7 @@ def TempDirWithoutEnvVars(*env_vars):
 
 @contextmanager
 def _scope_env(**env: str) -> Iterator[None]:
-    """Add `env` to the environment and remove them after testing
-    is complete.
-    """
+    """Add `env` to the environment and remove them after testing is complete."""  # noqa: E501
     env_save = {key: os.environ.get(key) for key in env}
     try:
         os.environ.update(env)

--- a/delocate/tests/pytest_tools.py
+++ b/delocate/tests/pytest_tools.py
@@ -2,6 +2,10 @@ import os
 
 import pytest
 
+# ruff: noqa
+# I recommend removing this module entirely. -@HexDecimal
+# Assert functions confuse pytest, in_tmp_path is not used.
+
 
 def assert_true(condition):
     __tracebackhide__ = True

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -1,4 +1,4 @@
-""" Tests for relocating libraries """
+"""Tests for relocating libraries."""
 
 from __future__ import division, print_function
 

--- a/delocate/tests/test_fuse.py
+++ b/delocate/tests/test_fuse.py
@@ -1,5 +1,4 @@
-""" Test fusing two directory trees / wheels
-"""
+"""Test fusing two directory trees / wheels."""
 
 import os
 import shutil

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -1,4 +1,4 @@
-""" Tests for install name utilities """
+"""Tests for install name utilities."""
 
 import contextlib
 import os
@@ -199,7 +199,7 @@ def _copy_libs(lib_files, out_path):
 def assert_raises_if_exception(
     exception: object,
 ) -> ContextManager[object]:
-    """Returns a pytest.raises context if `exception` is an Exception type."""
+    """Return a pytest.raises context if `exception` is an Exception type."""
     if isinstance(exception, type) and issubclass(exception, Exception):
         return pytest.raises(exception)
     return contextlib.nullcontext()
@@ -218,7 +218,7 @@ class ToolArchMock(NamedTuple):
     def mock_subprocess_run(
         self, cmd: Sequence[str], *args: object, **kwargs: object
     ) -> CompletedProcess:
-        """A function to mock subprocess.run with this objects commands."""
+        """Mock subprocess.run with this objects commands."""
         return CompletedProcess(cmd, 0, stdout=self.commands[tuple(cmd)])
 
 

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -1,6 +1,6 @@
-""" Tests for libsana module
+"""Tests for libsana module.
 
-Utilities for analyzing library dependencies in trees and wheels
+Utilities for analyzing library dependencies in trees and wheels.
 """
 
 import os

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -1,10 +1,10 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
-""" Test scripts
+"""Test scripts.
 
 If we appear to be running from the development directory, use the scripts in
 the top-level folder ``scripts``.  Otherwise try and get the scripts from the
-path
+path.
 """
 from __future__ import annotations
 

--- a/delocate/tests/test_tmpdirs.py
+++ b/delocate/tests/test_tmpdirs.py
@@ -1,4 +1,4 @@
-""" Test tmpdirs module """
+"""Test tmpdirs module."""
 from __future__ import absolute_import, division, print_function
 
 from os import getcwd

--- a/delocate/tests/test_tools.py
+++ b/delocate/tests/test_tools.py
@@ -1,4 +1,4 @@
-""" Test tools module """
+"""Test tools module."""
 from __future__ import division, print_function
 
 import os
@@ -272,7 +272,7 @@ def test_get_archs_fuse():
 def test_validate_signature() -> None:
     # Fully test the validate_signature tool
     def check_signature(filename: str) -> None:
-        """Raises CalledProcessError if the signature can not be verified."""
+        """Raise CalledProcessError if the signature can not be verified."""
         subprocess.run(["codesign", "--verify", filename], check=True)
 
     with InTemporaryDirectory():

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -1,4 +1,4 @@
-""" Direct tests of fixes to wheels """
+"""Direct tests of fixes to wheels."""
 from __future__ import annotations
 
 import os
@@ -405,9 +405,7 @@ def test_fix_rpath():
 
         # Now test filters with recursive dependencies.
         def ignore_libextfunc(path: str) -> bool:
-            """Ignore libextfunc which will also ignore its dependency and
-            include no files.
-            """
+            """Ignore libextfunc which will also ignore its dependency and include no files."""  # noqa: E501
             return "libextfunc_rpath.dylib" not in path
 
         assert (

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -350,7 +350,7 @@ def test_patch_wheel() -> None:
         shutil.copyfile(PURE_WHEEL, "copied.whl")
         zip2dir("copied.whl", "wheel2")
         with open(pjoin("wheel2", "fakepkg2", "__init__.py"), "rt") as fobj:
-            assert fobj.read() == ""
+            assert fobj.read() == '"""Fake package."""\n'
         # Overwrite input wheel (the default)
         patch_wheel("copied.whl", WHEEL_PATCH)
         # Patched

--- a/delocate/tests/test_wheeltools.py
+++ b/delocate/tests/test_wheeltools.py
@@ -1,5 +1,4 @@
-""" Tests for wheeltools utilities
-"""
+"""Tests for wheeltools utilities."""
 
 import os
 import re

--- a/delocate/tmpdirs.py
+++ b/delocate/tmpdirs.py
@@ -6,9 +6,7 @@
 #   copyright and license terms.
 #
 ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-"""
-Contexts for *with* statement providing temporary directories
-"""
+"""Contexts for *with* statement providing temporary directories."""
 from __future__ import absolute_import, division, print_function
 
 import os
@@ -17,8 +15,9 @@ from tempfile import mkdtemp, template
 
 
 class TemporaryDirectory(object):
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.
+    r"""Create and return a temporary directory.
+
+    This has the same behavior as mkdtemp but can be used as a context manager.
 
     Upon exiting the context, the directory and everything contained
     in it are removed.
@@ -29,7 +28,7 @@ class TemporaryDirectory(object):
     >>> with TemporaryDirectory() as tmpdir:
     ...     fname = os.path.join(tmpdir, 'example_file.txt')
     ...     with open(fname, 'wt') as fobj:
-    ...         _ = fobj.write('a string\\n')
+    ...         _ = fobj.write('a string\n')
     >>> os.path.exists(tmpdir)
     False
     """
@@ -39,20 +38,23 @@ class TemporaryDirectory(object):
         self._closed = False
 
     def __enter__(self):
+        """Return the directory managed by this context."""
         return self.name
 
     def cleanup(self):
+        """Delete the directory managed by this context if it exists."""
         if not self._closed:
             shutil.rmtree(self.name)
             self._closed = True
 
     def __exit__(self, exc, value, tb):
+        """Clean up the directory on exit."""
         self.cleanup()
         return False
 
 
 class InTemporaryDirectory(TemporaryDirectory):
-    """Create, return, and change directory to a temporary directory
+    """Create, return, and change directory to a temporary directory.
 
     Examples
     --------
@@ -69,17 +71,19 @@ class InTemporaryDirectory(TemporaryDirectory):
     """
 
     def __enter__(self):
+        """Chdir to the managed directory and then return its path."""
         self._pwd = os.getcwd()
         os.chdir(self.name)
         return super(InTemporaryDirectory, self).__enter__()
 
     def __exit__(self, exc, value, tb):
+        """Revert the working directory then delete the managed directory."""
         os.chdir(self._pwd)
         return super(InTemporaryDirectory, self).__exit__(exc, value, tb)
 
 
 class InGivenDirectory(object):
-    """Change directory to given directory for duration of ``with`` block
+    """Change directory to given directory for duration of ``with`` block.
 
     Useful when you want to use `InTemporaryDirectory` for the final test, but
     you are still debugging.  For example, you may want to do this in the end:
@@ -103,7 +107,7 @@ class InGivenDirectory(object):
     """
 
     def __init__(self, path=None):
-        """Initialize directory context manager
+        """Initialize directory context manager.
 
         Parameters
         ----------
@@ -116,6 +120,7 @@ class InGivenDirectory(object):
         self.path = os.path.abspath(path)
 
     def __enter__(self):
+        """Chdir to the managed directory, creating it if needed."""
         self._pwd = os.path.abspath(os.getcwd())
         if not os.path.isdir(self.path):
             os.mkdir(self.path)
@@ -123,4 +128,5 @@ class InGivenDirectory(object):
         return self.path
 
     def __exit__(self, exc, value, tb):
+        """Revert the working directory."""
         os.chdir(self._pwd)

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -1,4 +1,4 @@
-""" Tools for getting and setting install names """
+"""Tools for getting and setting install names."""
 from __future__ import annotations
 
 import logging
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 class InstallNameError(Exception):
-    pass
+    """Errors reading or modifying macOS install name identifiers."""
 
 
 def back_tick(
@@ -42,9 +42,9 @@ def back_tick(
     as_str: bool = True,
     raise_err: Optional[bool] = None,
 ) -> Any:
-    """Run command `cmd`, return stdout, or stdout, stderr if `ret_err`
+    """Run command `cmd`, return stdout, or stdout, stderr if `ret_err`.
 
-    Roughly equivalent to ``check_output`` in Python 2.7
+    Roughly equivalent to ``check_output`` in Python 2.7.
 
     Parameters
     ----------
@@ -105,7 +105,7 @@ def back_tick(
 def _run(
     cmd: Sequence[str], *, check: bool
 ) -> subprocess.CompletedProcess[str]:
-    """Run ``cmd`` capturing output and handling non-zero exit codes by default.
+    r"""Run ``cmd`` capturing output and handling non-zero exit codes by default.
 
     Parameters
     ----------
@@ -129,7 +129,7 @@ def _run(
     Examples
     --------
     >>> _run(["python", "-c", "print('hello')"], check=True)
-    CompletedProcess(args=['python', '-c', "print('hello')"], returncode=0, stdout='hello\\n', stderr='')
+    CompletedProcess(args=['python', '-c', "print('hello')"], returncode=0, stdout='hello\n', stderr='')
     >>> _run(["python", "-c", "print('hello'); raise SystemExit('world')"], check=True)
     Traceback (most recent call last):
         ...
@@ -183,7 +183,7 @@ def _is_macho_file(filename: str | os.PathLike[str]) -> bool:
 
 
 def unique_by_index(sequence):
-    """unique elements in `sequence` in the order in which they occur
+    """Return unique elements in `sequence` in the order in which they occur.
 
     Parameters
     ----------
@@ -203,12 +203,12 @@ def unique_by_index(sequence):
 
 
 def chmod_perms(fname):
-    # Permissions relevant to chmod
+    """Return permissions relevant to chmod."""
     return stat.S_IMODE(os.stat(fname).st_mode)
 
 
 def ensure_permissions(mode_flags=stat.S_IWUSR):
-    """decorator to ensure a filename has given permissions.
+    """Decorate a function to ensure a filename has given permissions.
 
     If changed, original permissions are restored after the decorated
     modification.
@@ -248,7 +248,7 @@ IN_RE = re.compile(
 
 
 def parse_install_name(line: str) -> Tuple[str, str, str]:
-    """Parse a line of install name output
+    """Parse a line of install name output.
 
     Parameters
     ----------
@@ -344,7 +344,7 @@ def _parse_otool_listing(stdout: str) -> Dict[str, List[str]]:
     Traceback (most recent call last):
         ...
     RuntimeError: Input has duplicate architectures for ...
-    '''
+    '''  # noqa: D301
     stdout = stdout.strip()
     out: Dict[str, List[str]] = {}
     lines = stdout.split("\n")
@@ -418,7 +418,7 @@ def _check_ignore_archs(input: Dict[str, T]) -> T:
 def _parse_otool_install_names(
     stdout: str,
 ) -> Dict[str, List[Tuple[str, str, str]]]:
-    '''Parse the stdout of 'otool -L' and return
+    '''Parse the stdout of 'otool -L' and return.
 
     Parameters
     ----------
@@ -449,7 +449,7 @@ def _parse_otool_install_names(
     ... \t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.100.5)
     ... """)
     {'': [('/usr/lib/libc++.1.dylib', '1.0.0', '905.6.0'), ('/usr/lib/libSystem.B.dylib', '1.0.0', '1292.100.5')]}
-    '''  # noqa: E501
+    '''  # noqa: E501, D301
     out: Dict[str, List[Tuple[str, str, str]]] = {}
     for arch, install_names in _parse_otool_listing(stdout).items():
         out[arch] = [parse_install_name(name) for name in install_names]
@@ -525,9 +525,9 @@ def _line0_says_object(stdout_stderr: str, filename: str) -> bool:
 
 
 def get_install_names(filename: str) -> Tuple[str, ...]:
-    """Return install names from library named in `filename`
+    """Return install names from library named in `filename`.
 
-    Returns tuple of install names
+    Returns tuple of install names.
 
     tuple will be empty if no install names, or if this is not an object file.
 
@@ -566,7 +566,7 @@ def get_install_names(filename: str) -> Tuple[str, ...]:
 
 
 def get_install_id(filename: str) -> Optional[str]:
-    """Return install id from library named in `filename`
+    """Return install id from library named in `filename`.
 
     Returns None if no install id, or if this is not an object file.
 
@@ -634,7 +634,7 @@ def _get_install_ids(filename: str) -> Dict[str, str]:
 def set_install_name(
     filename: str, oldname: str, newname: str, ad_hoc_sign: bool = True
 ) -> None:
-    """Set install name `oldname` to `newname` in library filename
+    """Set install name `oldname` to `newname` in library filename.
 
     Parameters
     ----------
@@ -663,7 +663,7 @@ def set_install_name(
 
 @ensure_writable
 def set_install_id(filename: str, install_id: str, ad_hoc_sign: bool = True):
-    """Set install id for library named in `filename`
+    """Set install id for library named in `filename`.
 
     Parameters
     ----------
@@ -778,8 +778,7 @@ def get_rpaths(filename: str) -> Tuple[str, ...]:
 
 
 def get_environment_variable_paths():
-    """Return a tuple of entries in `DYLD_LIBRARY_PATH` and
-    `DYLD_FALLBACK_LIBRARY_PATH`.
+    """Return a tuple of entries in `DYLD_LIBRARY_PATH` and `DYLD_FALLBACK_LIBRARY_PATH`.
 
     This will allow us to search those locations for dependencies of libraries
     as well as `@rpath` entries.
@@ -788,7 +787,7 @@ def get_environment_variable_paths():
     -------
     env_var_paths : tuple
         path entries in environment variables
-    """
+    """  # noqa: E501
     # We'll search the extra library paths in a specific order:
     # DYLD_LIBRARY_PATH and then DYLD_FALLBACK_LIBRARY_PATH
     env_var_paths = []
@@ -803,7 +802,7 @@ def get_environment_variable_paths():
 
 @ensure_writable
 def add_rpath(filename: str, newpath: str, ad_hoc_sign: bool = True) -> None:
-    """Add rpath `newpath` to library `filename`
+    """Add rpath `newpath` to library `filename`.
 
     Parameters
     ----------
@@ -824,7 +823,7 @@ _SANITARY_RPATH = re.compile(r"^@loader_path/|^@executable_path/")
 
 
 def _is_rpath_sanitary(rpath: str) -> bool:
-    """Returns True if `rpath` is considered sanitary.
+    """Return True if `rpath` is considered sanitary.
 
     Includes only paths relative to `@executable_path` or `@loader_path`.
 
@@ -850,7 +849,7 @@ def _is_rpath_sanitary(rpath: str) -> bool:
 
 @ensure_writable
 def _remove_absolute_rpaths(filename: str, ad_hoc_sign: bool = True) -> None:
-    """Remove absolute filename rpaths in `filename`
+    """Remove absolute filename rpaths in `filename`.
 
     Parameters
     ----------
@@ -874,7 +873,7 @@ def _remove_absolute_rpaths(filename: str, ad_hoc_sign: bool = True) -> None:
 def zip2dir(
     zip_fname: str | PathLike[str], out_dir: str | PathLike[str]
 ) -> None:
-    """Extract `zip_fname` into output directory `out_dir`
+    """Extract `zip_fname` into output directory `out_dir`.
 
     Parameters
     ----------
@@ -909,7 +908,7 @@ _DateTuple = Tuple[int, int, int, int, int, int]
 def _get_zip_datetime(
     date_time: Optional[_DateTuple] = None,
 ) -> Optional[_DateTuple]:
-    """Utility function to support reproducible builds
+    """Return ``SOURCE_DATE_EPOCH`` if set, otherwise return `date_time`.
 
     https://reproducible-builds.org/docs/source-date-epoch/
 
@@ -939,7 +938,7 @@ def dir2zip(
     compress_level: int = -1,
     date_time: Optional[_DateTuple] = None,
 ) -> None:
-    """Make a zip file `zip_fname` with contents of directory `in_dir`
+    """Make a zip file `zip_fname` with contents of directory `in_dir`.
 
     The recorded filenames are relative to `in_dir`, so doing a standard zip
     unpack of the resulting `zip_fname` in an empty directory will result in
@@ -985,7 +984,7 @@ def dir2zip(
 
 
 def find_package_dirs(root_path: str) -> Set[str]:
-    """Find python package directories in directory `root_path`
+    """Find python package directories in directory `root_path`.
 
     Parameters
     ----------
@@ -1007,7 +1006,7 @@ def find_package_dirs(root_path: str) -> Set[str]:
 
 
 def cmp_contents(filename1, filename2):
-    """Returns True if contents of the files are the same
+    """Return True if contents of the files are the same.
 
     Parameters
     ----------
@@ -1030,7 +1029,7 @@ def cmp_contents(filename1, filename2):
 
 
 def get_archs(libname: str) -> FrozenSet[str]:
-    """Return architecture types from library `libname`
+    """Return architecture types from library `libname`.
 
     Parameters
     ----------
@@ -1072,7 +1071,7 @@ def get_archs(libname: str) -> FrozenSet[str]:
 def lipo_fuse(
     in_fname1: str, in_fname2: str, out_fname: str, ad_hoc_sign: bool = True
 ) -> str:
-    """Use lipo to merge libs `filename1`, `filename2`, store in `out_fname`
+    """Use lipo to merge libs `filename1`, `filename2`, store in `out_fname`.
 
     Parameters
     ----------
@@ -1101,9 +1100,9 @@ def lipo_fuse(
 
 @ensure_writable
 def replace_signature(filename: str, identity: str) -> None:
-    """Replace the signature of a binary file using `identity`
+    """Replace the signature of a binary file using `identity`.
 
-    See the codesign documentation for more info
+    See the codesign documentation for more info.
 
     Parameters
     ----------
@@ -1116,12 +1115,12 @@ def replace_signature(filename: str, identity: str) -> None:
 
 
 def validate_signature(filename: str) -> None:
-    """Remove invalid signatures from a binary file
+    """Remove invalid signatures from a binary file.
 
-    If the file signature is missing or valid then it will be ignored
+    If the file signature is missing or valid then it will be ignored.
 
-    Invalid signatures are replaced with an ad-hoc signature.  This is the
-    closest you can get to removing a signature on MacOS
+    Invalid signatures are replaced with an ad-hoc signature.
+    This is the closest you can get to removing a signature on MacOS.
 
     Parameters
     ----------

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -1,6 +1,6 @@
-""" General tools for working with wheels
+"""General tools for working with wheels.
 
-Tools that aren't specific to delocation
+Tools that aren't specific to delocation.
 """
 
 import base64
@@ -24,22 +24,22 @@ from .tools import dir2zip, open_rw, unique_by_index, zip2dir
 
 
 class WheelToolsError(Exception):
-    pass
+    """Errors raised when reading or writing wheel files."""
 
 
 def _open_for_csv(name, mode):
-    """Deal with Python 2/3 open API differences"""
+    """Deal with Python 2/3 open API differences."""
     if sys.version_info[0] < 3:
         return open_rw(name, mode + "b")
     return open_rw(name, mode, newline="", encoding="utf-8")
 
 
 def rewrite_record(bdist_dir: str) -> None:
-    """Rewrite RECORD file with hashes for all files in `wheel_sdir`
+    """Rewrite RECORD file with hashes for all files in `wheel_sdir`.
 
-    Copied from :method:`wheel.bdist_wheel.bdist_wheel.write_record`
+    Copied from :method:`wheel.bdist_wheel.bdist_wheel.write_record`.
 
-    Will also unsign wheel
+    Will also unsign wheel.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def rewrite_record(bdist_dir: str) -> None:
 
 
 class InWheel(InTemporaryDirectory):
-    """Context manager for doing things inside wheels
+    """Context manager for doing things inside wheels.
 
     On entering, you'll find yourself in the root tree of the wheel.  If you've
     asked for an output wheel, then on exit we'll rewrite the wheel record and
@@ -93,7 +93,7 @@ class InWheel(InTemporaryDirectory):
     """
 
     def __init__(self, in_wheel, out_wheel=None, ret_self=False):
-        """Initialize in-wheel context manager
+        """Initialize in-wheel context manager.
 
         Parameters
         ----------
@@ -111,10 +111,18 @@ class InWheel(InTemporaryDirectory):
         super(InWheel, self).__init__()
 
     def __enter__(self):
+        """Unpack a wheel and return the path to its temporary directly.
+
+        Will also chdir to the temporary directory.
+        """
         zip2dir(self.in_wheel, self.name)
         return super(InWheel, self).__enter__()
 
     def __exit__(self, exc, value, tb):
+        """Write out the wheel based on the value of `out_wheel`, then cleanup.
+
+        Reverts the working directory and deletes the temporary directory.
+        """
         if self.out_wheel is not None:
             rewrite_record(self.name)
             dir2zip(self.name, self.out_wheel)
@@ -122,7 +130,7 @@ class InWheel(InTemporaryDirectory):
 
 
 class InWheelCtx(InWheel):
-    """Context manager for doing things inside wheels
+    """Context manager for doing things inside wheels.
 
     On entering, you'll find yourself in the root tree of the wheel.  If you've
     asked for an output wheel, then on exit we'll rewrite the wheel record and
@@ -130,7 +138,7 @@ class InWheelCtx(InWheel):
 
     The context manager returns itself from the __enter__ method, so you can
     set things like ``out_wheel``.  This is useful when processing in the wheel
-    will dicate what the output wheel name is, or whether you want to save at
+    will dictate what the output wheel name is, or whether you want to save at
     all.
 
     The current path of the wheel contents is set in the attribute
@@ -138,7 +146,7 @@ class InWheelCtx(InWheel):
     """
 
     def __init__(self, in_wheel, out_wheel=None):
-        """Init in-wheel context manager returning self from enter
+        """Init in-wheel context manager returning self from enter.
 
         Parameters
         ----------
@@ -152,6 +160,11 @@ class InWheelCtx(InWheel):
         self.wheel_path = None
 
     def __enter__(self):
+        # NOTICE: this method breaks the Liskov substitution principle.
+        """Unpack a wheel to a temporary directory and return self.
+
+        Will also chdir to the temporary directory.
+        """
         self.wheel_path = super(InWheelCtx, self).__enter__()
         return self
 
@@ -182,7 +195,7 @@ def add_platforms(
     out_path: Optional[str] = None,
     clobber: bool = False,
 ) -> Optional[str]:
-    """Add platform tags `platforms` to `in_wheel` filename and WHEEL tags
+    """Add platform tags `platforms` to `in_wheel` filename and WHEEL tags.
 
     Add any platform tags in `platforms` that are missing from `in_wheel`
     filename.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "machomachomangler; sys_platform == 'win32'",
     "packaging>=20.9",
     "typing_extensions",
-    "macholib"
+    "macholib",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -53,18 +53,23 @@ addopts = ["--doctest-modules", "--cov=delocate", "--cov-config=.coveragerc"]
 log_file_level = "DEBUG"
 
 [tool.ruff]
-# https://beta.ruff.rs/docs/rules/
+line-length = 80
+
+[tool.ruff.lint] # https://docs.astral.sh/ruff/rules/
 select = [
     "E", # pycodestyle
     "W", # pycodestyle
     "F", # Pyflakes
     "I", # isort
+    "D", # pydocstyle
 ]
 ignore = [
     "ANN101", # missing-type-self
     "ANN102", # missing-type-cls
 ]
-line-length = 80
+
+[tool.ruff.lint.per-file-ignores]
+"test_*.py" = ["D103"] # Docstrings not required for test functions
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" setup script for delocate package """
+"""Setup script for delocate package."""
 from os.path import join as pjoin
 
 from setuptools import find_packages, setup

--- a/wheel_makers/fakepkg1/fakepkg1/__init__.py
+++ b/wheel_makers/fakepkg1/fakepkg1/__init__.py
@@ -1,0 +1,1 @@
+"""Fake package."""

--- a/wheel_makers/fakepkg1/fakepkg1/module1.py
+++ b/wheel_makers/fakepkg1/fakepkg1/module1.py
@@ -1,5 +1,6 @@
-""" First module """
+"""First module."""
 
 
-def func1():
+def func1() -> int:
+    """Return 1."""
     return 1

--- a/wheel_makers/fakepkg1/fakepkg1/subpkg/__init__.py
+++ b/wheel_makers/fakepkg1/fakepkg1/subpkg/__init__.py
@@ -1,0 +1,1 @@
+"""Sub-package module."""

--- a/wheel_makers/fakepkg1/fakepkg1/tests/__init__.py
+++ b/wheel_makers/fakepkg1/fakepkg1/tests/__init__.py
@@ -1,1 +1,1 @@
-# Make tests a package
+"""Tests package."""

--- a/wheel_makers/fakepkg1/fakepkg1/tests/test_fakepkg.py
+++ b/wheel_makers/fakepkg1/fakepkg1/tests/test_fakepkg.py
@@ -1,3 +1,4 @@
+"""Local package tests."""
 from delocate.tests.pytest_tools import assert_equal
 
 from ..module1 import func1

--- a/wheel_makers/fakepkg1/scripts/fakescript.py
+++ b/wheel_makers/fakepkg1/scripts/fakescript.py
@@ -1,11 +1,11 @@
 #!python
-""" A fake script
-"""
+"""A fake script."""
 
 import fakepkg1.subpkg.module2  # noqa: F401
 
 
 def main():
+    """Print a message."""
     print("Fake.  Script")
 
 

--- a/wheel_makers/fakepkg1/setup.py
+++ b/wheel_makers/fakepkg1/setup.py
@@ -1,4 +1,4 @@
-""" Setup for fakepkg1
+"""Setup for fakepkg1.
 
 fakepkg1 is a - fake package - that has extensions and links against an external
 dynamic lib.  We use it to build a wheel, then test we can delocate it.

--- a/wheel_makers/fakepkg2/fakepkg2/__init__.py
+++ b/wheel_makers/fakepkg2/fakepkg2/__init__.py
@@ -1,0 +1,1 @@
+"""Fake package."""

--- a/wheel_makers/fakepkg2/fakepkg2/module1.py
+++ b/wheel_makers/fakepkg2/fakepkg2/module1.py
@@ -1,5 +1,6 @@
-""" First module """
+"""First module."""
 
 
 def func1():
+    """Return 1."""
     return 1

--- a/wheel_makers/fakepkg2/fakepkg2/subpkg/__init__.py
+++ b/wheel_makers/fakepkg2/fakepkg2/subpkg/__init__.py
@@ -1,0 +1,1 @@
+"""Sub-package module."""

--- a/wheel_makers/fakepkg2/fakepkg2/subpkg/module2.py
+++ b/wheel_makers/fakepkg2/fakepkg2/subpkg/module2.py
@@ -1,9 +1,11 @@
-""" Second module """
+"""Second module."""
 
 
 def func2():
+    """Return 2."""
     return 2
 
 
 def func3():
+    """Return 3."""
     return 3

--- a/wheel_makers/fakepkg2/fakepkg2/tests/__init__.py
+++ b/wheel_makers/fakepkg2/fakepkg2/tests/__init__.py
@@ -1,1 +1,1 @@
-# Make tests a package
+"""Tests package."""

--- a/wheel_makers/fakepkg2/fakepkg2/tests/test_fakepkg.py
+++ b/wheel_makers/fakepkg2/fakepkg2/tests/test_fakepkg.py
@@ -1,3 +1,4 @@
+"""Local package tests."""
 from delocate.tests.pytest_tools import assert_equal
 
 from ..module1 import func1

--- a/wheel_makers/fakepkg2/setup.py
+++ b/wheel_makers/fakepkg2/setup.py
@@ -1,4 +1,4 @@
-""" Setup for fakepkg1
+"""Setup for fakepkg1.
 
 fakepkg2 is a - fake package - with Python only. We use it to build a wheel,
 then test we can delocate it.

--- a/wheel_makers/fakepkg_namespace/namespace/subpkg/__init__.py
+++ b/wheel_makers/fakepkg_namespace/namespace/subpkg/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package."""

--- a/wheel_makers/fakepkg_namespace/namespace/subpkg/tests/__init__.py
+++ b/wheel_makers/fakepkg_namespace/namespace/subpkg/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package."""

--- a/wheel_makers/fakepkg_namespace/namespace/subpkg/tests/test_fakepkg.py
+++ b/wheel_makers/fakepkg_namespace/namespace/subpkg/tests/test_fakepkg.py
@@ -1,3 +1,4 @@
+"""Local package tests."""
 from namespace.subpkg.module2 import func2, func3  # type: ignore
 
 

--- a/wheel_makers/fakepkg_namespace/setup.py
+++ b/wheel_makers/fakepkg_namespace/setup.py
@@ -1,3 +1,4 @@
+"""Setup a namespace package with an extension linked to an external library."""
 import subprocess
 from pathlib import Path
 

--- a/wheel_makers/fakepkg_rpath/fakepkg/__init__.py
+++ b/wheel_makers/fakepkg_rpath/fakepkg/__init__.py
@@ -1,0 +1,1 @@
+"""Fake package."""

--- a/wheel_makers/fakepkg_rpath/fakepkg/module1.py
+++ b/wheel_makers/fakepkg_rpath/fakepkg/module1.py
@@ -1,5 +1,6 @@
-""" First module """
+"""First module."""
 
 
 def func1():
+    """Return 1."""
     return 1

--- a/wheel_makers/fakepkg_rpath/fakepkg/subpkg/__init__.py
+++ b/wheel_makers/fakepkg_rpath/fakepkg/subpkg/__init__.py
@@ -1,0 +1,1 @@
+"""Sub-package module."""

--- a/wheel_makers/fakepkg_rpath/fakepkg/tests/__init__.py
+++ b/wheel_makers/fakepkg_rpath/fakepkg/tests/__init__.py
@@ -1,1 +1,1 @@
-# Make tests a package
+"""Tests package."""

--- a/wheel_makers/fakepkg_rpath/fakepkg/tests/test_fakepkg.py
+++ b/wheel_makers/fakepkg_rpath/fakepkg/tests/test_fakepkg.py
@@ -1,3 +1,4 @@
+"""Local package tests."""
 from delocate.tests.pytest_tools import assert_equal
 
 from ..module1 import func1

--- a/wheel_makers/fakepkg_rpath/setup.py
+++ b/wheel_makers/fakepkg_rpath/setup.py
@@ -1,4 +1,4 @@
-""" Setup for fakepkg_rpath
+"""Setup for fakepkg_rpath.
 
 This fake package has an extension which links against a library using @rpath
 in its install name.  The library will also be signed with an ad-hoc signature.

--- a/wheel_makers/fakepkg_toplevel/setup.py
+++ b/wheel_makers/fakepkg_toplevel/setup.py
@@ -1,3 +1,4 @@
+"""Setup package with an extension linked to an external library."""
 import subprocess
 from pathlib import Path
 

--- a/wheel_makers/fakepkg_toplevel/test_fakepkg_toplevel.py
+++ b/wheel_makers/fakepkg_toplevel/test_fakepkg_toplevel.py
@@ -1,3 +1,4 @@
+"""Test fake package."""
 from module2 import func2, func3  # type: ignore
 
 


### PR DESCRIPTION
Updated `.pre-commit-config.yaml` and removed `default_language_version` for now as it was overly strict and causing minor issues.

Enabled the `pydocstyle` rule for Ruff and updated the `pyproject.toml` file to a less deprecated layout.

Applied the new rule to all relevant files. Includes adding docstrings to some functions and modules which were missing any.

These changes are not meant to affect any code, although a test involving patched wheels was updated to be aware of a modules new docstring.