### PR TITLE
If wheel has no package directories, use lib_sdir as a suffix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,12 @@ rules on making a good Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- `delocate-wheel` `--lib-sdir` now changes the suffix of the bundled library
+  directory.
+  [#210](https://github.com/matthew-brett/delocate/pull/210)
+
 ### Changed
 
 - Improved error message for when a MacOS target version is not met.

--- a/delocate/cmd/delocate_wheel.py
+++ b/delocate/cmd/delocate_wheel.py
@@ -40,7 +40,9 @@ parser.add_argument(
     action="store",
     type=str,
     default=".dylibs",
-    help="Subdirectory in packages to store copied libraries",
+    help="Subdirectory in packages to store copied libraries"
+    "\nFor non-package wheels this will be used as a suffix for the library "
+    "directory",
 )
 parser.add_argument(
     "-w",

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -543,7 +543,7 @@ def _decide_dylib_bundle_directory(
     lib_sdir : str, optional
         Default value for lib sub-directory passed in via
         :func:`delocate_wheel`.
-        Ignored if wheel has no package directories.
+        If wheel has no package directories, used as a suffix.
 
     Returns
     -------
@@ -559,7 +559,7 @@ def _decide_dylib_bundle_directory(
         # Otherwise, store dylib files in the first package alphabetically.
         return pjoin(min(package_dirs), lib_sdir)
     # Otherwise, use an auditwheel-style top-level name.
-    return pjoin(wheel_dir, f"{package_name}.dylibs")
+    return pjoin(wheel_dir, f"{package_name}{lib_sdir}")
 
 
 def _make_install_name_ids_unique(

--- a/delocate/tests/test_wheelies.py
+++ b/delocate/tests/test_wheelies.py
@@ -455,12 +455,14 @@ def test_fix_toplevel() -> None:
 
         assert (
             delocate_wheel(
-                TOPLEVEL_WHEEL, "out-1.0-cp39-cp39-macosx_10_9_x86_64.whl"
+                TOPLEVEL_WHEEL,
+                "out-1.0-cp39-cp39-macosx_10_9_x86_64.whl",
+                lib_sdir=".suffix_test",
             )
             == stray_libs
         )
         with InWheel("out-1.0-cp39-cp39-macosx_10_9_x86_64.whl") as wheel_path:
-            assert "fakepkg_toplevel.dylibs" in os.listdir(wheel_path)
+            assert "fakepkg_toplevel.suffix_test" in os.listdir(wheel_path)
 
 
 @pytest.mark.xfail(sys.platform != "darwin", reason="otool")


### PR DESCRIPTION
Currently, there is no way to customize libs dir if the wheel has no package directory.

One use case is an extension, that offers C-API (like the gmpy2 package).  With above patch you could set one to something common for all platforms.