### PR TITLE
Improve error message for when a MacOS target version is not met

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,11 @@ rules on making a good Changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- Improved error message for when a MacOS target version is not met.
+  [#211](https://github.com/matthew-brett/delocate/issues/211)
+
 ## [0.11.0] - 2024-03-22
 
 ### Added

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -836,10 +836,17 @@ def _check_and_update_wheel_name(
             f"{lib_path} has a minimum target of {lib_macos_version}"
             for lib_path, lib_macos_version in problematic_files
         )
+        min_valid_version = max(
+            lib_macos_version for _, lib_macos_version in problematic_files
+        )
         raise DelocationError(
             "Library dependencies do not satisfy target MacOS"
             f" version {require_target_macos_version}:\n"
             f"{problematic_files_str}"
+            f"\nUse '--require-target-macos-version {min_valid_version}'"
+            " or set the environment variable"
+            f" 'MACOSX_DEPLOYMENT_TARGET={min_valid_version}'"
+            " to update this wheels supported version."
         )
     if new_name != wheel_name:
         wheel_path = wheel_path.parent / new_name

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -846,7 +846,7 @@ def _check_and_update_wheel_name(
             f"\nUse '--require-target-macos-version {min_valid_version}'"
             " or set the environment variable"
             f" 'MACOSX_DEPLOYMENT_TARGET={min_valid_version}'"
-            " to update this wheels supported version."
+            " to update minimum supported macOS for this wheel."
         )
     if new_name != wheel_name:
         wheel_path = wheel_path.parent / new_name

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -804,6 +804,8 @@ def test_delocate_wheel_verify_name_universal2_verify_crash(
     assert result.returncode != 0
     assert "Library dependencies do not satisfy target MacOS" in result.stderr
     assert "libam1.dylib has a minimum target of 12.0" in result.stderr
+    assert "MACOSX_DEPLOYMENT_TARGET=12.0" in result.stderr
+    assert "--require-target-macos-version 12.0" in result.stderr
 
 
 @pytest.mark.xfail(  # type: ignore[misc]
@@ -833,3 +835,5 @@ def test_delocate_wheel_verify_name_universal2_verify_crash_env_var(
     assert "Library dependencies do not satisfy target MacOS" in result.stderr
     assert "libam1.dylib has a minimum target of 12.0" in result.stderr
     assert "module2.abi3.so has a minimum target of 11.0" not in result.stderr
+    assert "MACOSX_DEPLOYMENT_TARGET=12.0" in result.stderr
+    assert "--require-target-macos-version 12.0" in result.stderr


### PR DESCRIPTION
Adds clear instructions for how to update the MacOS target version when the current target is not met.

Closes #211