### PR TITLE
Retag wheels automatically when fusing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,9 @@ rules on making a good Changelog.
 
 - Improved error message for when a MacOS target version is not met.
   [#211](https://github.com/matthew-brett/delocate/issues/211)
+- Retag wheels automatically when fusing to ensure the wheel name and WHEEL
+  file tag data is accurate.
+  [#215](https://github.com/matthew-brett/delocate/pull/215)
 
 ## [0.11.0] - 2024-03-22
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,8 +14,8 @@ rules on making a good Changelog.
 
 - Improved error message for when a MacOS target version is not met.
   [#211](https://github.com/matthew-brett/delocate/issues/211)
-- Retag wheels automatically when fusing to ensure the wheel name and WHEEL
-  file tag data is accurate.
+- `delocate-fuse` will now output to a new wheel with updated tags instead of
+  replacing the first wheel given.
   [#215](https://github.com/matthew-brett/delocate/pull/215)
 
 ## [0.11.0] - 2024-03-22

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,8 +14,11 @@ rules on making a good Changelog.
 
 - Improved error message for when a MacOS target version is not met.
   [#211](https://github.com/matthew-brett/delocate/issues/211)
-- `delocate-fuse` will now output to a new wheel with updated tags instead of
-  replacing the first wheel given.
+- `delocate-fuse` is no longer available and will throw an error when invoked.
+  To fuse two wheels together use `delocate-merge`. `delocate-merge` does not
+  overwrite the first wheel. It creates a new wheel with an automatically
+  determined name. If the old behavior is needed (not recommended), pin the
+  version to `delocate==0.11.0`.
   [#215](https://github.com/matthew-brett/delocate/pull/215)
 
 ## [0.11.0] - 2024-03-22

--- a/README.rst
+++ b/README.rst
@@ -183,17 +183,17 @@ One solution to this problem is to do an entire ``arm64`` wheel build, and then
 an entire ``x86_64`` wheel build, and *fuse* the two wheels into a universal
 wheel.
 
-That is what the ``delocate-fuse`` command does.
+That is what the ``delocate-merge`` command does.
 
 Let's say you have built an ARM and Intel wheel, called, respectively:
 
 * ``scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl``
 * ``scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl``
 
-Then you could create a new fused (``universal2``) wheel in the `tmp`
+Then you could create a new fused (``universal2``) wheel in the ``tmp``
 subdirectory with::
 
-    delocate-fuse scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl -w tmp
+    delocate-merge scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl scipy-1.9.3-cp311-cp311-macosx_10_9_x86_64.whl -w tmp
 
 The output wheel in that case would be:
 
@@ -201,6 +201,18 @@ The output wheel in that case would be:
 
 In the new wheel, you will find, using ``lipo -archs`` - that all binaries with
 the same name in each wheel are now universal (``x86_64`` and ``arm64``).
+
+    `:warning:` **Note:** In previous versions (``<0.12.0``) making dual architecture binaries was
+    performed with the ``delocate-fuse`` command. This commannd would overwrite the
+    first wheel passed in by default. This led to the user needing to rename the
+    wheel to correctly describe what platforms it supported. For this and other
+    reasons, wheels created with this were often incorrect. From version ``0.12.0``
+    and on, the ``delocate-fuse`` command has been removed and replaced with
+    ``delocate-merge``. The ``delocate-merge`` command will create a new wheel with an
+    automatically generated name based on the wheels that were merged together.
+    There is no need to perform any further changes to the merged wheel's name. If
+    the old behavior is needed (not recommended), pin the version to
+    ``delocate==0.11.0``.
 
 Troubleshooting
 ===============

--- a/README.rst
+++ b/README.rst
@@ -197,20 +197,10 @@ subdirectory with::
 
 The output wheel in that case would be:
 
-* ``tmp/scipy-1.9.3-cp311-cp311-macosx_12_0_arm64.whl``
-
-Note that we specified an output directory above with the ``-w`` flag.  If we
-had not done that, then we overwrite the first wheel with the fused wheel.  And
-note that the wheel written into the ``tmp`` subdirectory has the same name as
-the first-specified wheel.
+* ``tmp/scipy-1.9.3-cp311-cp311-macosx_12_0_universal2.whl``
 
 In the new wheel, you will find, using ``lipo -archs`` - that all binaries with
 the same name in each wheel are now universal (``x86_64`` and ``arm64``).
-
-To be useful, you should rename the output wheel to reflect the fact that it is
-now a universal wheel - in this case to:
-
-* ``tmp/scipy-1.9.3-cp311-cp311-macosx_12_0_universal2.whl``
 
 Troubleshooting
 ===============

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -19,7 +19,7 @@ def main() -> None:  # noqa: D103
         " name. If the old behavior is needed (not recommended), pin the"
         " version to 'delocate==0.11.0'."
     )
-    return 1
+    raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -34,8 +34,7 @@ def main() -> None:  # noqa: D103
     wheel1, wheel2 = [Path(wheel).resolve(strict=True) for wheel in args.wheels]
     if args.wheel_dir is not None:
         out_wheel = Path(args.wheel_dir).resolve()
-        if not out_wheel.exists():
-            out_wheel.mkdir(parents=True)
+        out_wheel.mkdir(parents=True, exist_ok=True)
     else:
         out_wheel = None
     fuse_wheels(wheel1, wheel2, out_wheel)

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -1,43 +1,25 @@
 #!/usr/bin/env python3
 """Fuse two (probably delocated) wheels.
 
-Writes to a new wheel with an automatically determined name by default.
+Command is no longer available. To fuse two wheels together use
+'delocate-merge'. NOTE: 'delocate-merge' does not overwrite the first wheel. It
+creates a new wheel with an automatically determined name. If the old behavior
+is needed (not recommended), pin the version to 'delocate==0.11.0'.
 """
 
 # vim: ft=python
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from pathlib import Path
-
-from delocate.cmd.common import common_parser, verbosity_config
-from delocate.fuse import fuse_wheels
-
-parser = ArgumentParser(description=__doc__, parents=[common_parser])
-parser.add_argument(
-    "wheels", nargs=2, metavar="WHEEL", type=str, help="Wheels to fuse"
-)
-parser.add_argument(
-    "-w",
-    "--wheel-dir",
-    action="store",
-    type=str,
-    help="Directory to store delocated wheels"
-    " (default is to store in the same directory as the 1st WHEEL with an"
-    " automatically determined name).",
-)
-
 
 def main() -> None:  # noqa: D103
-    args = parser.parse_args()
-    verbosity_config(args)
-    wheel1, wheel2 = [Path(wheel).resolve(strict=True) for wheel in args.wheels]
-    if args.wheel_dir is not None:
-        out_wheel = Path(args.wheel_dir).resolve()
-        out_wheel.mkdir(parents=True, exist_ok=True)
-    else:
-        out_wheel = None
-    fuse_wheels(wheel1, wheel2, out_wheel)
+    print(
+        "'delocate-fuse' is no longer available. To fuse two wheels together"
+        " use 'delocate-merge'. NOTE: 'delocate-merge' does not overwrite the"
+        " first wheel. It creates a new wheel with an automatically determined"
+        " name. If the old behavior is needed (not recommended), pin the"
+        " version to 'delocate==0.11.0'."
+    )
+    return 1
 
 
 if __name__ == "__main__":

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -26,6 +26,12 @@ parser.add_argument(
     help="Directory to store delocated wheels"
     " (default is to overwrite 1st WHEEL input with 2nd)",
 )
+parser.add_argument(
+    "--retag",
+    action="store_true",
+    help="Retag the fused wheel. This includes updating its filename and"
+    " dist-info (Only works when fusing to make a universal2 wheel)"
+)
 
 
 def main() -> None:  # noqa: D103
@@ -36,7 +42,7 @@ def main() -> None:  # noqa: D103
         out_wheel = wheel1
     else:
         out_wheel = pjoin(abspath(expanduser(args.wheel_dir)), basename(wheel1))
-    fuse_wheels(wheel1, wheel2, out_wheel)
+    fuse_wheels(wheel1, wheel2, out_wheel, retag=args.retag)
 
 
 if __name__ == "__main__":

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -30,7 +30,7 @@ parser.add_argument(
     "--retag",
     action="store_true",
     help="Retag the fused wheel. This includes updating its filename and"
-    " dist-info (Only works when fusing to make a universal2 wheel)"
+    " dist-info (Only works when fusing to make a universal2 wheel)",
 )
 
 

--- a/delocate/cmd/delocate_fuse.py
+++ b/delocate/cmd/delocate_fuse.py
@@ -5,7 +5,7 @@ Writes to a new wheel with an automatically determined name by default.
 """
 
 # vim: ft=python
-from __future__ import absolute_import, division, print_function
+from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path
@@ -31,7 +31,7 @@ parser.add_argument(
 def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
-    wheel1, wheel2 = [Path(wheel).resolve() for wheel in args.wheels]
+    wheel1, wheel2 = [Path(wheel).resolve(strict=True) for wheel in args.wheels]
     if args.wheel_dir is not None:
         out_wheel = Path(args.wheel_dir).resolve()
         if not out_wheel.exists():

--- a/delocate/cmd/delocate_merge.py
+++ b/delocate/cmd/delocate_merge.py
@@ -32,11 +32,10 @@ def main() -> None:  # noqa: D103
     args = parser.parse_args()
     verbosity_config(args)
     wheel1, wheel2 = [Path(wheel).resolve(strict=True) for wheel in args.wheels]
-    if args.wheel_dir is not None:
-        out_wheel = Path(args.wheel_dir).resolve()
-        out_wheel.mkdir(parents=True, exist_ok=True)
-    else:
-        out_wheel = None
+    out_wheel = Path(
+        args.wheel_dir if args.wheel_dir is not None else wheel1.parent
+    ).resolve()
+    out_wheel.mkdir(parents=True, exist_ok=True)
     fuse_wheels(wheel1, wheel2, out_wheel)
 
 

--- a/delocate/cmd/delocate_merge.py
+++ b/delocate/cmd/delocate_merge.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Fuse two (probably delocated) wheels.
+
+Writes to a new wheel with an automatically determined name by default.
+"""
+
+# vim: ft=python
+from __future__ import annotations
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+from delocate.cmd.common import common_parser, verbosity_config
+from delocate.fuse import fuse_wheels
+
+parser = ArgumentParser(description=__doc__, parents=[common_parser])
+parser.add_argument(
+    "wheels", nargs=2, metavar="WHEEL", type=str, help="Wheels to fuse"
+)
+parser.add_argument(
+    "-w",
+    "--wheel-dir",
+    action="store",
+    type=str,
+    help="Directory to store delocated wheels"
+    " (default is to store in the same directory as the 1st WHEEL with an"
+    " automatically determined name).",
+)
+
+
+def main() -> None:  # noqa: D103
+    args = parser.parse_args()
+    verbosity_config(args)
+    wheel1, wheel2 = [Path(wheel).resolve(strict=True) for wheel in args.wheels]
+    if args.wheel_dir is not None:
+        out_wheel = Path(args.wheel_dir).resolve()
+        out_wheel.mkdir(parents=True, exist_ok=True)
+    else:
+        out_wheel = None
+    fuse_wheels(wheel1, wheel2, out_wheel)
+
+
+if __name__ == "__main__":
+    main()

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -654,6 +654,14 @@ def _get_archs_and_version_from_wheel_name(
             raise ValueError(f"Invalid platform tag: {platform_tag.platform}")
         major, minor, arch = match.groups()
         platform_requirements[arch] = Version(f"{major}.{minor}")
+    # If we have a wheel name with arm64 and x86_64 we have to convert that to
+    # universal2
+    if set(platform_requirements.keys()) == set(("arm64", "x86_64")):
+        version = platform_requirements["arm64"]
+        if version == Version("11.0"):
+            version = platform_requirements["x86_64"]
+        platform_requirements = {"universal2": version}
+
     return platform_requirements
 
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -45,6 +45,7 @@ from .libsana import (
     tree_libs,
     tree_libs_from_directory,
 )
+from .pkginfo import read_pkg_info, write_pkg_info
 from .tmpdirs import TemporaryDirectory
 from .tools import (
     _is_macho_file,
@@ -867,14 +868,11 @@ def _update_wheelfile(wheel_dir: Path, wheel_name: str) -> None:
     """
     platform_tag_set = parse_wheel_filename(wheel_name)[-1]
     (file_path,) = wheel_dir.glob("*.dist-info/WHEEL")
-    with file_path.open(encoding="utf-8") as f:
-        lines = f.readlines()
-    with file_path.open("w", encoding="utf-8") as f:
-        for line in lines:
-            if line.startswith("Tag:"):
-                f.write(f"Tag: {'.'.join(str(x) for x in platform_tag_set)}\n")
-            else:
-                f.write(line)
+    info = read_pkg_info(file_path)
+    del info["Tag"]
+    for tag in platform_tag_set:
+        info.add_header("Tag", str(tag))
+    write_pkg_info(file_path, info)
 
 
 def delocate_wheel(

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -656,7 +656,7 @@ def _get_archs_and_version_from_wheel_name(
         platform_requirements[arch] = Version(f"{major}.{minor}")
     # If we have a wheel name with arm64 and x86_64 we have to convert that to
     # universal2
-    if set(platform_requirements.keys()) == set(("arm64", "x86_64")):
+    if platform_requirements.keys() == {"arm64", "x86_64"}:
         version = platform_requirements["arm64"]
         if version == Version("11.0"):
             version = platform_requirements["x86_64"]

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -12,6 +12,8 @@ with the same relative path in ``to_tree``]. In this case the two files are
 libraries.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 from os import PathLike
@@ -150,7 +152,9 @@ def fuse_wheels(
     out_wheel : Path
         The path of the new wheel from fusion of `to_wheel` and `from_wheel`.
     """
-    to_wheel, from_wheel = [Path(w).resolve() for w in (to_wheel, from_wheel)]
+    to_wheel, from_wheel = [
+        Path(w).resolve(strict=True) for w in (to_wheel, from_wheel)
+    ]
     out_wheel = (
         to_wheel.parent if out_wheel is None else Path(out_wheel).resolve()
     )

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -133,7 +133,7 @@ def fuse_trees(
 def fuse_wheels(
     to_wheel: str | PathLike,
     from_wheel: str | PathLike,
-    out_wheel: str | PathLike | None = None,
+    out_wheel: str | PathLike,
 ) -> Path:
     """Fuse `from_wheel` into `to_wheel`, write to `out_wheel`.
 
@@ -143,13 +143,11 @@ def fuse_wheels(
         The path of the wheel to fuse into.
     from_wheel : str or Path-like
         The path of the wheel to fuse from.
-    out_wheel : str or Path-like, optional
+    out_wheel : str or Path-like
         The path of the new wheel from fusion of `to_wheel` and `from_wheel`. If
         a full path is given, (including the filename) it will be used as is. If
         a directory is given, the fused wheel will be stored in the directory,
-        with the name of the wheel automatically determined. If no path is
-        given, the fused wheel will be stored in the same directory as
-        `to_wheel`, with the name of the wheel automatically determined.
+        with the name of the wheel automatically determined.
 
     Returns
     -------
@@ -161,9 +159,7 @@ def fuse_wheels(
     """
     to_wheel = Path(to_wheel).resolve(strict=True)
     from_wheel = Path(from_wheel).resolve(strict=True)
-    out_wheel = (
-        to_wheel.parent if out_wheel is None else Path(out_wheel).resolve()
-    )
+    out_wheel = Path(out_wheel)
     with tempfile.TemporaryDirectory() as temp_dir:
         to_wheel_dir = Path(temp_dir, "to_wheel")
         from_wheel_dir = Path(temp_dir, "from_wheel")

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -104,7 +104,7 @@ def fuse_trees(
     lib_exts : sequence, optional
         filename extensions for libraries
     """
-    for from_dirpath, dirnames, filenames in os.walk(str(from_tree)):
+    for from_dirpath, dirnames, filenames in os.walk(from_tree):
         to_dirpath = pjoin(to_tree, relpath(from_dirpath, from_tree))
         # Copy any missing directories in to_path
         for dirname in tuple(dirnames):
@@ -159,9 +159,8 @@ def fuse_wheels(
     .. versionchanged:: 0.12
         `out_wheel` can now take a directory or None.
     """
-    to_wheel, from_wheel = [
-        Path(w).resolve(strict=True) for w in (to_wheel, from_wheel)
-    ]
+    to_wheel = Path(to_wheel).resolve(strict=True)
+    from_wheel = Path(from_wheel).resolve(strict=True)
     out_wheel = (
         to_wheel.parent if out_wheel is None else Path(out_wheel).resolve()
     )

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -104,7 +104,7 @@ def fuse_trees(
     lib_exts : sequence, optional
         filename extensions for libraries
     """
-    for from_dirpath, dirnames, filenames in os.walk(from_tree):
+    for from_dirpath, dirnames, filenames in os.walk(Path(from_tree)):
         to_dirpath = pjoin(to_tree, relpath(from_dirpath, from_tree))
         # Copy any missing directories in to_path
         for dirname in tuple(dirnames):

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -727,6 +727,11 @@ def test_get_archs_and_version_from_wheel_name() -> None:
     ) == {
         "universal2": Version("10.9"),
     }
+    assert _get_archs_and_version_from_wheel_name(
+        "foo-1.0-py310-abi3-macosx_10_9_x86_64.macosx_12_0_arm64.whl"
+    ) == {
+        "universal2": Version("12.0"),
+    }
     with pytest.raises(InvalidWheelFilename, match="Invalid wheel filename"):
         _get_archs_and_version_from_wheel_name("foo.whl")
 

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -724,7 +724,9 @@ def test_get_archs_and_version_from_wheel_name() -> None:
     }
     assert _get_archs_and_version_from_wheel_name(
         "foo-1.0-py310-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.whl"
-    )
+    ) == {
+        "universal2": Version("10.9"),
+    }
     with pytest.raises(InvalidWheelFilename, match="Invalid wheel filename"):
         _get_archs_and_version_from_wheel_name("foo.whl")
 

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -722,6 +722,9 @@ def test_get_archs_and_version_from_wheel_name() -> None:
     ) == {
         "arm64": Version("12.0"),
     }
+    assert _get_archs_and_version_from_wheel_name(
+        "foo-1.0-py310-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.whl"
+    )
     with pytest.raises(InvalidWheelFilename, match="Invalid wheel filename"):
         _get_archs_and_version_from_wheel_name("foo.whl")
 

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -402,20 +402,26 @@ def test_fix_wheel_archs(script_runner: ScriptRunner) -> None:
 def test_fuse_wheels(script_runner: ScriptRunner) -> None:
     # Some tests for wheel fusing
     with InTemporaryDirectory():
-        # Wheels need proper wheel filename for delocate-fuse
+        # Wheels need proper wheel filename for delocate-merge
         to_wheel = "to_" + basename(PLAT_WHEEL)
         from_wheel = "from_" + basename(PLAT_WHEEL)
         zip2dir(PLAT_WHEEL, "to_wheel")
         zip2dir(PLAT_WHEEL, "from_wheel")
         dir2zip("to_wheel", to_wheel)
         dir2zip("from_wheel", from_wheel)
-        script_runner.run(["delocate-fuse", to_wheel, from_wheel], check=True)
+        # Make sure delocate-fuse returns a non-zero exit code, it is no longer
+        # supported
+        result = script_runner.run(
+            ["delocate-fuse", to_wheel, from_wheel], check=True
+        )
+        assert result.returncode != 0
+        script_runner.run(["delocate-merge", to_wheel, from_wheel], check=True)
         zip2dir(to_wheel, "to_wheel_fused")
         assert_same_tree("to_wheel_fused", "from_wheel")
         # Test output argument
         os.mkdir("wheels")
         script_runner.run(
-            ["delocate-fuse", to_wheel, from_wheel, "-w", "wheels"],
+            ["delocate-merge", to_wheel, from_wheel, "-w", "wheels"],
             check=True,
         )
         zip2dir(pjoin("wheels", to_wheel), "to_wheel_refused")

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -411,9 +411,7 @@ def test_fuse_wheels(script_runner: ScriptRunner) -> None:
         dir2zip("from_wheel", from_wheel)
         # Make sure delocate-fuse returns a non-zero exit code, it is no longer
         # supported
-        result = script_runner.run(
-            ["delocate-fuse", to_wheel, from_wheel], check=True
-        )
+        result = script_runner.run(["delocate-fuse", to_wheel, from_wheel])
         assert result.returncode != 0
         script_runner.run(["delocate-merge", to_wheel, from_wheel], check=True)
         zip2dir(to_wheel, "to_wheel_fused")

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -402,22 +402,23 @@ def test_fix_wheel_archs(script_runner: ScriptRunner) -> None:
 def test_fuse_wheels(script_runner: ScriptRunner) -> None:
     # Some tests for wheel fusing
     with InTemporaryDirectory():
+        # Wheels need proper wheel filename for delocate-fuse
+        to_wheel = "to_" + basename(PLAT_WHEEL)
+        from_wheel = "from_" + basename(PLAT_WHEEL)
         zip2dir(PLAT_WHEEL, "to_wheel")
         zip2dir(PLAT_WHEEL, "from_wheel")
-        dir2zip("to_wheel", "to_wheel.whl")
-        dir2zip("from_wheel", "from_wheel.whl")
-        script_runner.run(
-            ["delocate-fuse", "to_wheel.whl", "from_wheel.whl"], check=True
-        )
-        zip2dir("to_wheel.whl", "to_wheel_fused")
+        dir2zip("to_wheel", to_wheel)
+        dir2zip("from_wheel", from_wheel)
+        script_runner.run(["delocate-fuse", to_wheel, from_wheel], check=True)
+        zip2dir(to_wheel, "to_wheel_fused")
         assert_same_tree("to_wheel_fused", "from_wheel")
         # Test output argument
         os.mkdir("wheels")
         script_runner.run(
-            ["delocate-fuse", "to_wheel.whl", "from_wheel.whl", "-w", "wheels"],
+            ["delocate-fuse", to_wheel, from_wheel, "-w", "wheels"],
             check=True,
         )
-        zip2dir(pjoin("wheels", "to_wheel.whl"), "to_wheel_refused")
+        zip2dir(pjoin("wheels", to_wheel), "to_wheel_refused")
         assert_same_tree("to_wheel_refused", "from_wheel")
 
 

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -10,6 +10,7 @@ import hashlib
 import os
 import sys
 from itertools import product
+from os import PathLike
 from os.path import abspath, basename, dirname, exists, relpath, splitext
 from os.path import join as pjoin
 from os.path import sep as psep
@@ -34,7 +35,7 @@ def _open_for_csv(name, mode):
     return open_rw(name, mode, newline="", encoding="utf-8")
 
 
-def rewrite_record(bdist_dir: str) -> None:
+def rewrite_record(bdist_dir: str | PathLike) -> None:
     """Rewrite RECORD file with hashes for all files in `wheel_sdir`.
 
     Copied from :method:`wheel.bdist_wheel.bdist_wheel.write_record`.
@@ -43,7 +44,7 @@ def rewrite_record(bdist_dir: str) -> None:
 
     Parameters
     ----------
-    bdist_dir : str
+    bdist_dir : str or Path-like
         Path of unpacked wheel file
     """
     info_dirs = glob.glob(pjoin(bdist_dir, "*.dist-info"))

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -3,6 +3,8 @@
 Tools that aren't specific to delocation.
 """
 
+from __future__ import annotations
+
 import base64
 import csv
 import glob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 delocate-addplat = "delocate.cmd.delocate_addplat:main"
 delocate-fuse = "delocate.cmd.delocate_fuse:main"
 delocate-listdeps = "delocate.cmd.delocate_listdeps:main"
+delocate-merge = "delocate.cmd.delocate_merge:main"
 delocate-patch = "delocate.cmd.delocate_patch:main"
 delocate-path = "delocate.cmd.delocate_path:main"
 delocate-wheel = "delocate.cmd.delocate_wheel:main"


### PR DESCRIPTION
This is my attempt at a PR for #174.

This adds the ability to "retag" a universal2 fused wheel. When running delocate-fuse with this flag, it will update the filename and the dist-info file of the fused wheel to reflect that it is a universal2 wheel.

I didn't update the readme or add any tests yet. I wanted to first get feedback on whether or not this is the "retag" you had in mind.

Let me know what you think/if there is anything you would like changed!