### PR TITLE
fix string formatting in error message

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,12 @@ rules on making a good Changelog.
   version to `delocate==0.11.0`.
   [#215](https://github.com/matthew-brett/delocate/pull/215)
 
+### Fixed
+
+- Existing libraries causing DelocationError were not shown due to bad string
+  formatting.
+  [#216](https://github.com/matthew-brett/delocate/pull/216)
+
 ## [0.11.0] - 2024-03-22
 
 ### Added

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -992,7 +992,7 @@ def delocate_wheel(
         )
         if copied_libs and lib_path_exists_before_delocate:
             raise DelocationError(
-                "f{lib_path} already exists in wheel but need to copy "
+                f"{lib_path} already exists in wheel but need to copy "
                 + "; ".join(copied_libs)
             )
         if len(os.listdir(lib_path)) == 0:

--- a/delocate/tests/test_libsana.py
+++ b/delocate/tests/test_libsana.py
@@ -463,7 +463,9 @@ def test_wheel_libs_ignore_missing() -> None:
     # Test wheel_libs ignore_missing parameter.
     with InTemporaryDirectory() as tmpdir:
         shutil.copy(RPATH_WHEEL, pjoin(tmpdir, "rpath.whl"))
-        with pytest.raises(DelocationError):
+        with pytest.raises(
+            DelocationError, match=r"Could not find all dependencies."
+        ):
             wheel_libs("rpath.whl")
         wheel_libs("rpath.whl", ignore_missing=True)
 


### PR DESCRIPTION
Thanks for this awesome project!

I noticed tonight that an error message is printing with the literal string `f{lib_path}` in it, like this:

> delocate.libsana.DelocationError: f{lib_path} already exists in wheel but need to copy /opt/homebrew/Cellar/libomp/17.0.6/lib/libomp.dylib

I strongly suspect that was supposed to be an f-string, where `{lib_path}` is replaced in the error message with a path to a library.

This proposes that fix.