### PR TITLE
Configure trusted publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -185,6 +185,9 @@ jobs:
     needs: isolated_tests
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    environment:
+      name: deploy
+      url: https://pypi.org/project/delocate/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -202,8 +205,6 @@ jobs:
         with:
           name: delocate-sdist
           path: dist/
-      - name: Upload to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload dist/* --non-interactive --skip-existing
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
Replaces my API token with trusted publishing as described in #196. Closes #196

I have enough access to handle on rest on PyPI but a GitHub user can't setup an environment on another users private repo. @matthew-brett will need to do the following:

* On this repo, go to: Setting > Enviroments > New environment
* Name the new environment: `deploy`
* Optionally setup deployment protection rules

Only then can I finish this PR.