### PR TITLE
Apply suggestions to the deployment workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/delocate/${{ github.ref_name }}
+      url: https://pypi.org/project/delocate/${{ github.ref_name }}/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: ${{ github.ref_name }}
+      url: https://pypi.org/project/delocate/${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -183,11 +183,11 @@ jobs:
 
   deploy:
     needs: isolated_tests
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     environment:
-      name: deploy
-      url: https://pypi.org/project/delocate/
+      name: pypi
+      url: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -206,5 +206,3 @@ jobs:
           name: delocate-sdist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true


### PR DESCRIPTION
I merged #220 too early. @webknjaz has suggested several small tweaks to that PR, this PR applies them. My initial configuration was outdated.

Apologies to @matthew-brett, if you setup any of the optional security stuff with the `deploy` environment then you should do the same with a `pypi` environment. If you didn't do any of the extras then apparently the environment will be automatically created on-demand and you won't need to do anything.