### PR TITLE
Prepare 0.12.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.10
+    rev: v0.6.2
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ A guide for maintainers who are doing a Delocate release.
   Check whether there are outstanding issues that can be closed, and whether there are any issues that should delay the release.
   Label them!
 
-- Review and update the release notes.
-  Review and update the `Changelog` file.
+- Review and update the `Changelog.md` file.
+  Add the new version/date while preserving the `[Unreleased]` header.
+
   Get a partial list of contributors with something like::
 
       git shortlog -ns 0.6.0..
@@ -69,14 +70,14 @@ A guide for maintainers who are doing a Delocate release.
 
 #### Doing the release
 
-You might want to make tag the release commit on your local machine, push to [PyPI](https://pypi.org/project/delocate), review, fix, rebase, until all is good.
-Then and only then do you push to upstream on github.
+Once the above is done the commit can be tagged and uploaded.
 
 - Make an annotated tag for the release with tag of form `0.6.0`::
 
       git tag -a 0.6.0
 
-- Push the tag with something like `git push origin 0.6.0` and that tag will be automatically deployed to PyPI.
+- Push the tag to `matthew-brett/delocate` to automatically deploy to PyPI.
+  If the remote name for the `matthew-brett/delocate` repo is `origin` then the command would be `git push origin 0.6.0`.
 
 - Check how everything looks on PyPI - the description, the packages.
   If anything doesn't look right then yank the release and upload with the patch version incremented.

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ rules on making a good Changelog.
 
 ## [Unreleased]
 
+## [0.12.0] - 2024-08-29
+
 ### Added
 
 - `delocate-wheel` `--lib-sdir` now changes the suffix of the bundled library
@@ -19,7 +21,8 @@ rules on making a good Changelog.
 ### Changed
 
 - Sanitize rpaths (`--sanitize-rpaths`) is now the default behavior.
-  Opt out with new `--no-sanitize-rpaths` [#223](https://github.com/matthew-brett/delocate/pull/223)
+  Opt-out with the new `--no-sanitize-rpaths` flag.
+  [#223](https://github.com/matthew-brett/delocate/pull/223)
 - Improved error message for when a MacOS target version is not met.
   [#211](https://github.com/matthew-brett/delocate/issues/211)
 - `delocate-fuse` is no longer available and will throw an error when invoked.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Provides scripts:
 * ``delocate-path`` -- copy libraries a tree depends on into the tree and relink
 * ``delocate-wheel`` -- rewrite wheel having copied and relinked library
   dependencies into the wheel tree.
-* ``delocate-fuse`` -- combine two wheels with different architectures into one
+* ``delocate-merge`` -- combine two wheels with different architectures into one
   wheel with dual architecture binaries.
 
 `Auditwheel <https://github.com/pypa/auditwheel>`_ is a similar tool for Linux.
@@ -267,8 +267,8 @@ See https://github.com/matthew-brett/delocate
 Released under the BSD two-clause license - see the file ``LICENSE`` in the
 source distribution.
 
-`travis-ci <https://travis-ci.org/matthew-brett/delocate>`_ kindly tests the
-code automatically under Python 3.6 through 3.9.
+`GitHub Actions <https://github.com/matthew-brett/delocate/actions>`_
+kindly tests the code automatically.
 
 The latest released version is at https://pypi.python.org/pypi/delocate
 


### PR DESCRIPTION
Update readme to mention delocate-merge instead of delocate-fuse, change TravisCI URL to GitHub Actions.

Update release instructions

Update and run pre-commit hooks

I really should've taken the initiative and performed this release sooner. The readme had mentioned unreleased features for too long, and there were pending bug fixes.