### PR TITLE
Refactor dependency discovery to handle multiple architectures

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,14 +45,14 @@ jobs:
 
   tests:
     needs: [pre-commit, mypy]
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "14.0"
+          xcode-version: "14.2"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
@@ -134,11 +134,14 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: "macos-12"
-            xcode: "14.0"
-            python: "3.x"
           - os: "macos-13"
             xcode: "14.2"
+            python: "3.x"
+          - os: "macos-14"
+            xcode: "15.4"
+            python: "3.x"
+          - os: "macos-15"
+            xcode: "16.0"
             python: "3.x"
           - os: "ubuntu-latest"
             python: "3.9"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The `wheel_makers` directory holds scripts used to make test data. GitHub Action
 
 Use [pathlib](https://docs.python.org/3/library/pathlib.html) for any new code using paths.
 Refactor any touched functions to use pathlib when it does not break backwards compatibility.
-Prefer using `PurePosixPath` to handle relative library paths returned from MacOS tools such as `otool`.
+Prefer using `str` to handle paths returned from MacOS tools such as `otool`.
 
 All new functions must have [type hints](https://mypy.readthedocs.io/en/stable/getting_started.html).
 All touched functions must be refactored to use type hints, including test functions.

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,15 @@ rules on making a good Changelog.
 - `patch_wheel` function raises `FileNotFoundError` instead of `ValueError` on
   missing patch files.
 
+### Fixed
+
+- Fixed `NotImplementedError` when libraries depend on differing binaries
+  per-architecture.
+  [#230](https://github.com/matthew-brett/delocate/pull/230)
+- Now checks all architectures instead of an arbitrary default.
+  This was causing inconsistent behavior across MacOS versions.
+  [#230](https://github.com/matthew-brett/delocate/pull/230)
+
 ### Removed
 
 - Dropped support for Python 3.7 and Python 3.8.

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,12 @@ rules on making a good Changelog.
 - `patch_wheel` function raises `FileNotFoundError` instead of `ValueError` on
   missing patch files.
 
+### Deprecated
+
+- `get_rpaths` and `get_install_id` are deprecated due to not supporting
+  architectures.
+- `unique_by_index` is deprecated. Use more-itertools unique_everseen instead.
+
 ### Fixed
 
 - Fixed `NotImplementedError` when libraries depend on differing binaries

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -9,7 +9,6 @@ import sys
 from collections.abc import Sequence
 from os.path import basename, dirname, exists
 from os.path import join as pjoin
-from pathlib import Path, PurePosixPath
 from subprocess import CompletedProcess
 from typing import (
     NamedTuple,
@@ -425,17 +424,12 @@ cmdsize 0
     ],
 )
 def test_names_multi(arch_def: ToolArchMock) -> None:
-    def _as_posix(paths) -> list[PurePosixPath]:
-        """Ensure paths are POSIX on all platforms."""
-        return [PurePosixPath(Path(path)) for path in paths]
-
     with mock.patch("subprocess.run", arch_def.mock_subprocess_run):
         with mock.patch("delocate.tools._is_macho_file", return_value=True):
             with assert_raises_if_exception(arch_def.expected_install_names):
-                assert _as_posix(get_install_names("example.so")) == _as_posix(
-                    arch_def.expected_install_names
+                assert (
+                    get_install_names("example.so")
+                    == arch_def.expected_install_names
                 )
             with assert_raises_if_exception(arch_def.expected_rpaths):
-                assert _as_posix(get_rpaths("example.so")) == _as_posix(
-                    arch_def.expected_rpaths
-                )
+                assert get_rpaths("example.so") == arch_def.expected_rpaths

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -365,7 +365,10 @@ cmdsize 0
    path path/arm64 (offset 0)
 """,
             },
-            expected_install_names=NotImplementedError,
+            expected_install_names=(
+                "/usr/lib/libc++.1.dylib",
+                "/usr/lib/libSystem.B.dylib",
+            ),
             expected_rpaths=NotImplementedError,
         ),
         ToolArchMock(
@@ -415,7 +418,7 @@ cmdsize 0
    path path/x86_64 (offset 0)
 """,
             },
-            expected_install_names=NotImplementedError,
+            expected_install_names=InstallNameError,  # Bad install id
             expected_rpaths=("path/x86_64",),
         ),
     ],

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -226,6 +226,8 @@ class ToolArchMock(NamedTuple):
             commands={
                 (
                     "otool",
+                    "-arch",
+                    "all",
                     "-L",
                     "example.so",
                 ): """\
@@ -236,6 +238,8 @@ example.so:
 """,  # noqa: E501
                 (
                     "otool",
+                    "-arch",
+                    "all",
                     "-D",
                     "example.so",
                 ): """\
@@ -244,6 +248,8 @@ example.so:
 """,
                 (
                     "otool",
+                    "-arch",
+                    "all",
                     "-l",
                     "example.so",
                 ): """\
@@ -263,6 +269,8 @@ cmdsize 0
             commands={
                 (  # Install names match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-L",
                     "example.so",
                 ): """\
@@ -277,6 +285,8 @@ example.so (architecture arm64):
 """,  # noqa: E501
                 (  # Install IDs match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-D",
                     "example.so",
                 ): """\
@@ -287,6 +297,8 @@ example.so (architecture arm64):
 """,
                 (  # Rpaths match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-l",
                     "example.so",
                 ): """\
@@ -310,6 +322,8 @@ cmdsize 0
             commands={  # Multi arch - not matching install names, rpaths
                 (  # Install names do not match (compatibility version).
                     "otool",
+                    "-arch",
+                    "all",
                     "-L",
                     "example.so",
                 ): """\
@@ -324,6 +338,8 @@ example.so (architecture arm64):
 """,  # noqa: E501
                 (  # Install IDs match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-D",
                     "example.so",
                 ): """\
@@ -334,6 +350,8 @@ example.so (architecture arm64):
 """,
                 (  # Rpaths do not match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-l",
                     "example.so",
                 ): """\
@@ -354,6 +372,8 @@ cmdsize 0
             commands={  # Multi arch - not matching install IDS
                 (  # Install names match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-L",
                     "example.so",
                 ): """\
@@ -368,6 +388,8 @@ example.so (architecture arm64):
 """,  # noqa: E501
                 (  # Different install IDs for different archs.
                     "otool",
+                    "-arch",
+                    "all",
                     "-D",
                     "example.so",
                 ): """\
@@ -378,6 +400,8 @@ example.so (architecture arm64):
 """,
                 (  # RPaths match.
                     "otool",
+                    "-arch",
+                    "all",
                     "-l",
                     "example.so",
                 ): """\

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -194,7 +194,7 @@ def _unique_everseen(iterable: Iterable[T], /) -> Iterator[T]:
             yield element
 
 
-@deprecated("Use unique_everseen instead")
+@deprecated("Use more-itertools unique_everseen instead")
 def unique_by_index(sequence: Iterable[T]) -> list[T]:
     """Return unique elements in `sequence` in the order in which they occur.
 
@@ -207,6 +207,9 @@ def unique_by_index(sequence: Iterable[T]) -> list[T]:
     uniques : list
         unique elements of sequence, ordered by the order in which the element
         occurs in `sequence`
+
+    .. deprecated:: 0.12
+        Use more-itertools unique_everseen instead.
     """
     return list(_unique_everseen(sequence))
 
@@ -632,6 +635,10 @@ def get_install_id(filename: str) -> str | None:
     ------
     NotImplementedError
         If ``filename`` has different install ids per-architecture.
+
+    .. deprecated:: 0.12
+        This function has been replaced by the private function
+        `_get_install_ids`.
     """
     install_ids = _get_install_ids(filename)
     if not install_ids:
@@ -850,6 +857,9 @@ def get_rpaths(filename: str | PathLike[str]) -> tuple[str, ...]:
         If ``filename`` has different rpaths per-architecture.
     InstallNameError
         On any unexpected output from ``otool``.
+
+    .. deprecated:: 0.12
+        This function has been replaced by the private function `_get_rpaths`.
     """
     # Simply return all rpaths ignoring architectures
     return tuple(

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -542,7 +542,7 @@ def get_install_names(filename: str) -> tuple[str, ...]:
     """
     if not _is_macho_file(filename):
         return ()
-    otool = _run(["otool", "-L", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-L", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()
     install_id = get_install_id(filename)
@@ -606,7 +606,7 @@ def _get_install_ids(filename: str) -> dict[str, str]:
     """
     if not _is_macho_file(filename):
         return {}
-    otool = _run(["otool", "-D", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-D", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return {}
     out = {}
@@ -762,7 +762,7 @@ def get_rpaths(filename: str) -> tuple[str, ...]:
     """
     if not _is_macho_file(filename):
         return ()
-    otool = _run(["otool", "-l", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-l", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return ()
     rpaths = _check_ignore_archs(_parse_otool_rpaths(otool.stdout))

--- a/delocate/wheeltools.py
+++ b/delocate/wheeltools.py
@@ -24,7 +24,7 @@ from packaging.utils import parse_wheel_filename
 from delocate.pkginfo import read_pkg_info, write_pkg_info
 
 from .tmpdirs import InTemporaryDirectory
-from .tools import dir2zip, open_rw, unique_by_index, zip2dir
+from .tools import _unique_everseen, dir2zip, open_rw, zip2dir
 
 
 class WheelToolsError(Exception):
@@ -246,7 +246,7 @@ def add_platforms(
         # Python version, C-API version combinations
         pyc_apis = ["-".join(tag.split("-")[:2]) for tag in in_info_tags]
         # unique Python version, C-API version combinations
-        pyc_apis = unique_by_index(pyc_apis)
+        pyc_apis = list(_unique_everseen(pyc_apis))
         # Add new platform tags for each Python version, C-API combination
         required_tags = ["-".join(tup) for tup in product(pyc_apis, platforms)]
         needs_write = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "bindepend; sys_platform == 'win32'",
     "machomachomangler; sys_platform == 'win32'",
     "packaging>=20.9",
-    "typing_extensions",
+    "typing_extensions>=4.12.2",
     "macholib",
 ]
 classifiers = [


### PR DESCRIPTION
`get_dependencies` and what it calls has been refactored to handle dependencies organized by architecture. Delocate is now aware of multiple architectures and should handle the most common cases where libraries depend on different things depending on their architecture. Fixes #153 Fixes #154

`_check_ignore_archs` is being phased out. Most of the work was in `get_dependencies`, `get_install_names`, and `get_rpaths`. I made new private versions of some of these so that they could have an updated return value needed to track the architecture.

Adding `-arch all` to all `otool` calls makes `otool` act like it does in later MacOS versions. The tests added in #140 no longer expect `NotImplementedError`. Fixing this also allows testing on newer MacOS runners which I've added. Closes #137

I tried to switch functions which return library data to return `PurePosixPath` but this causes it to remove trailing slashes on folders and the functions which edit library data need the strings be match exactly, so there's no point in switching those functions over to return Path types. I did update much of what I touched to use pathlib inputs though.

This PR is a mess so far. I'll likely squash this before merging.

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/master/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/master/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests
