### PR TITLE
Append delocate version to wheel metadata

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-# .coveragerc to control coverage.py
-[run]
-omit =
-    */_version.py
-    */tests/*

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ rules on making a good Changelog.
   missing patch files.
 - `delocate.fuse.fuse_trees` now auto-detects binary files instead of testing
   filename suffixes.
+- `delocate-wheel` and `delocate-fuse` now appends the delocate version used to
+  the wheels metadata.
 
 ### Deprecated
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -51,6 +51,11 @@ from .tools import (
 )
 from .wheeltools import InWheel, rewrite_record
 
+try:
+    from delocate._version import __version__
+except ImportError:  # pragma: no cover
+    __version__ = ""
+
 logger = logging.getLogger(__name__)
 
 # Prefix for install_name_id of copied libraries
@@ -923,9 +928,15 @@ def _check_and_update_wheel_name(
     return wheel_path
 
 
+def _get_delocate_generator_header() -> tuple[str, str]:
+    """Return Delocate's version info to be appended to the WHEEL metadata."""
+    return ("Generator", f"delocate {__version__}".rstrip())
+
+
 def _update_wheelfile(wheel_dir: Path, wheel_name: str) -> None:
-    """
-    Update the WHEEL file in the wheel directory with the new platform tag.
+    """Update the WHEEL file in the wheel directory with updated metadata.
+
+    Updates the platform tag and marks the wheel as modified by delocate.
 
     Parameters
     ----------
@@ -935,12 +946,20 @@ def _update_wheelfile(wheel_dir: Path, wheel_name: str) -> None:
         The name of the wheel.
         Used for determining the new platform tag.
     """
-    platform_tag_set = parse_wheel_filename(wheel_name)[-1]
+    _name, _version, _, platform_tag_set = parse_wheel_filename(wheel_name)
     (file_path,) = wheel_dir.glob("*.dist-info/WHEEL")
     info = read_pkg_info(file_path)
+
+    # Update tags to match current wheel name
     del info["Tag"]
     for tag in platform_tag_set:
         info.add_header("Tag", str(tag))
+
+    # Mark wheel as modifed by this version of Delocate
+    delocate_generator = _get_delocate_generator_header()
+    if delocate_generator not in info.items():
+        info.add_header(*delocate_generator)
+
     write_pkg_info(file_path, info)
 
 
@@ -1073,7 +1092,6 @@ def delocate_wheel(
             libraries=libraries_in_lib_path,
             install_id_prefix=DLC_PREFIX + relpath(lib_sdir, wheel_dir),
         )
-        rewrite_record(wheel_dir)
         out_wheel_ = Path(out_wheel)
         out_wheel_fixed = _check_and_update_wheel_name(
             out_wheel_, Path(wheel_dir), require_target_macos_version
@@ -1081,7 +1099,8 @@ def delocate_wheel(
         if out_wheel_fixed != out_wheel_:
             out_wheel_ = out_wheel_fixed
             in_place = False
-            _update_wheelfile(Path(wheel_dir), out_wheel_.name)
+        _update_wheelfile(Path(wheel_dir), out_wheel_.name)
+        rewrite_record(wheel_dir)
         if len(copied_libs) or not in_place:
             if remove_old:
                 os.remove(in_wheel)

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -49,7 +49,7 @@ def _copyfile(in_fname, out_fname):
 
 
 def _retag_wheel(to_wheel: Path, from_wheel: Path, to_tree: Path) -> str:
-    """Update the name and dist-info to reflect a univeral2 wheel.
+    """Update the name and dist-info to reflect a universal2 wheel.
 
     Parameters
     ----------
@@ -68,8 +68,8 @@ def _retag_wheel(to_wheel: Path, from_wheel: Path, to_tree: Path) -> str:
     to_tree = to_tree.resolve()
     # Add from_wheel platform tags onto to_wheel filename, but make sure to not
     # add a tag if it is already there
-    from_wheel_tags = parse_wheel_filename(from_wheel.name)[-1]
-    to_wheel_tags = parse_wheel_filename(to_wheel.name)[-1]
+    _, _, _, from_wheel_tags = parse_wheel_filename(from_wheel.name)
+    _, _, _, to_wheel_tags = parse_wheel_filename(to_wheel.name)
     add_platform_tags = (
         f".{tag.platform}" for tag in from_wheel_tags - to_wheel_tags
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,13 @@ write_to = "delocate/_version.py"
 minversion = "6.0"
 required_plugins = ["pytest-console-scripts>=1.4.0", "pytest-cov"]
 testpaths = ["delocate/"]
-addopts = ["--doctest-modules", "--cov=delocate", "--cov-config=.coveragerc"]
+addopts = ["--doctest-modules", "--cov=delocate", "--cov-config=pyproject.toml"]
 log_file_level = "DEBUG"
+
+
+[tool.coverage.run]
+# Exclude files from coverage
+omit = ["*/_version.py", "*/tests/*"]
 
 
 [tool.mypy]


### PR DESCRIPTION
Adds the delocate version used to wheel metadata as suggested by the [Binary distribution format guidelines](https://packaging.python.org/en/latest/specifications/binary-distribution-format). The format is `delocate {version}` as shown in the guideline but I've seen other tools use `name ({version})` instead.

Tagging wheels like this will help with future issues if there's ever a long term problem with a specific version of delocate.

There seemed to be cases where `rewrite_record` could be called before modifications were done, this has been resolved.

Was also able to move `.coveragerc` into `pyproject.toml` so that's one less config file.

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/master/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/master/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests
