### PR TITLE
Ignore unparseable static libraries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ rules on making a good Changelog.
   [#230](https://github.com/matthew-brett/delocate/pull/230)
 - `delocate-merge` now supports libraries with missing or unusual extensions.
   [#228](https://github.com/matthew-brett/delocate/issues/228)
+- Now supports library files ending in parentheses.
 
 ### Removed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -34,6 +34,8 @@ rules on making a good Changelog.
 - `delocate-merge` now supports libraries with missing or unusual extensions.
   [#228](https://github.com/matthew-brett/delocate/issues/228)
 - Now supports library files ending in parentheses.
+- Fixed `Unknown Mach-O header` error when encountering a fat static library.
+  [#229](https://github.com/matthew-brett/delocate/issues/229)
 
 ### Removed
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -27,6 +27,7 @@ from macholib.mach_o import (  # type: ignore[import-untyped]
 from macholib.MachO import MachO  # type: ignore[import-untyped]
 from packaging.utils import parse_wheel_filename
 from packaging.version import Version
+from typing_extensions import deprecated
 
 from .libsana import (
     DelocationError,
@@ -249,6 +250,7 @@ def _update_install_names(
                 set_install_name(requiring, orig_install_name, new_install_name)
 
 
+@deprecated("copy_recurse is obsolete and should no longer be called")
 def copy_recurse(
     lib_path: str,
     copy_filt_func: Callable[[str], bool] | None = None,
@@ -291,11 +293,6 @@ def copy_recurse(
         This function is obsolete.  :func:`delocate_path` handles recursive
         dependencies while also supporting `@loader_path`.
     """
-    warnings.warn(
-        "copy_recurse is obsolete and should no longer be called.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if copied_libs is None:
         copied_libs = {}
     else:

--- a/delocate/libsana.py
+++ b/delocate/libsana.py
@@ -399,6 +399,7 @@ def _allow_all(path: str) -> bool:
     return True
 
 
+@deprecated("tree_libs doesn't support @loader_path and has been deprecated")
 def tree_libs(
     start_path: str,
     filt_func: Callable[[str], bool] | None = None,
@@ -443,11 +444,6 @@ def tree_libs(
 
         :func:`tree_libs_from_directory` should be used instead.
     """
-    warnings.warn(
-        "tree_libs doesn't support @loader_path and has been deprecated.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if filt_func is None:
         filt_func = _allow_all
     lib_dict: dict[str, dict[str, str]] = {}
@@ -559,7 +555,10 @@ def resolve_dynamic_paths(
     raise DependencyNotFound(lib_path)
 
 
-@deprecated("This function was replaced by resolve_dynamic_paths")
+@deprecated(
+    "This function doesn't support @loader_path "
+    "and was replaced by resolve_dynamic_paths"
+)
 def resolve_rpath(lib_path: str, rpaths: Iterable[str]) -> str:
     """Return `lib_path` with its `@rpath` resolved.
 
@@ -584,12 +583,6 @@ def resolve_rpath(lib_path: str, rpaths: Iterable[str]) -> str:
         This function does not support `@loader_path`.
         Use `resolve_dynamic_paths` instead.
     """
-    warnings.warn(
-        "resolve_rpath doesn't support @loader_path and has been deprecated."
-        "  Switch to using `resolve_dynamic_paths` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if not lib_path.startswith("@rpath/"):
         return lib_path
 

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -9,7 +9,6 @@ import re
 import stat
 import subprocess
 import time
-import warnings
 import zipfile
 from collections.abc import Iterable, Iterator, Sequence
 from datetime import datetime
@@ -33,6 +32,7 @@ class InstallNameError(Exception):
     """Errors reading or modifying macOS install name identifiers."""
 
 
+@deprecated("Replace this call with subprocess.run")
 def back_tick(
     cmd: str | Sequence[str],
     ret_err: bool = False,
@@ -73,11 +73,6 @@ def back_tick(
         This function was deprecated because the return type is too dynamic.
         You should use :func:`subprocess.run` instead.
     """
-    warnings.warn(
-        "back_tick is deprecated, replace this call with subprocess.run.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     if raise_err is None:
         raise_err = False if ret_err else True
     cmd_is_seq = isinstance(cmd, (list, tuple))

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -561,7 +561,7 @@ def _get_install_names(
     """
     if not _is_macho_file(filename):
         return {}
-    otool = _run(["otool", "-arch", "all", "-L", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-m", "-L", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return {}
     install_ids = _get_install_ids(filename)
@@ -664,7 +664,7 @@ def _get_install_ids(filename: str | PathLike[str]) -> dict[str, str]:
     """
     if not _is_macho_file(filename):
         return {}
-    otool = _run(["otool", "-arch", "all", "-D", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-m", "-D", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return {}
     out = {}
@@ -823,7 +823,7 @@ def _get_rpaths(
     """
     if not _is_macho_file(filename):
         return {}
-    otool = _run(["otool", "-arch", "all", "-l", filename], check=False)
+    otool = _run(["otool", "-arch", "all", "-m", "-l", filename], check=False)
     if not _line0_says_object(otool.stdout or otool.stderr, filename):
         return {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,7 @@ maintainers = [{ name = "Matthew Brett", email = "matthew.brett@gmail.com" }]
 readme = "README.rst"
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
-dependencies = [
-    "bindepend; sys_platform == 'win32'",
-    "machomachomangler; sys_platform == 'win32'",
-    "packaging>=20.9",
-    "typing_extensions>=4.12.2",
-    "macholib",
-]
+dependencies = ["packaging>=20.9", "typing_extensions>=4.12.2", "macholib"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/master/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/master/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests

This branch was an attempt to remove `macholib` and write a better `otool` parser but I underestimated how difficult the output of `otool` was. I wasn't able to resolve cases where it'd decide to not return the architecture info in its output because it decided it was the current systems architecture. In the end I decided it was more reliable to suppress the error from macholib instead of trying to remove the library.

This suppresses `ValueError: Unknown Mach-O header` which fixes #229, fixes #227. I don't have a fat static binary to test this such as an archive (`.a`) compiled for both `arm64` and `x86_64`.

While working on this I noticed the `-m` flag on `otool` and enabled it because delocate is always working with the whole file at once. This flag is documented as:
> -m The object file names are not assumed to be in the archive(member) syntax, which allows file names containing parenthesis.

I also looked at the previous install dependencies, `machomacomangler` and `bindepend`, and removed them because there was no code using them. These looked like previous attempts at cross-platform handling of MacOS binary files.