### PR TITLE
Smarter detection of binary files during delocate-merge

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@ rules on making a good Changelog.
 
 - `patch_wheel` function raises `FileNotFoundError` instead of `ValueError` on
   missing patch files.
+- `delocate.fuse.fuse_trees` now auto-detects binary files instead of testing
+  filename suffixes.
 
 ### Deprecated
 
@@ -29,6 +31,8 @@ rules on making a good Changelog.
 - Now checks all architectures instead of an arbitrary default.
   This was causing inconsistent behavior across MacOS versions.
   [#230](https://github.com/matthew-brett/delocate/pull/230)
+- `delocate-merge` now supports libraries with missing or unusual extensions.
+  [#228](https://github.com/matthew-brett/delocate/issues/228)
 
 ### Removed
 

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import warnings
+from collections.abc import Container
 from os import PathLike
-from os.path import exists, relpath, splitext
-from os.path import join as pjoin
 from pathlib import Path
 
 from packaging.utils import parse_wheel_filename
@@ -83,17 +83,18 @@ def _retag_wheel(to_wheel: Path, from_wheel: Path, to_tree: Path) -> str:
 
 
 def fuse_trees(
-    to_tree: str | PathLike,
-    from_tree: str | PathLike,
-    lib_exts=(".so", ".dylib", ".a"),
-):
+    to_tree: str | PathLike[str],
+    from_tree: str | PathLike[str],
+    lib_exts: Container[str] | None = None,
+) -> None:
     """Fuse path `from_tree` into path `to_tree`.
 
-    For each file in `from_tree` - check for library file extension (in
-    `lib_exts` - if present, check if there is a file with matching relative
-    path in `to_tree`, if so, use :func:`delocate.tools.lipo_fuse` to fuse the
-    two libraries together and write into `to_tree`.  If any of these
-    conditions are not met, just copy the file from `from_tree` to `to_tree`.
+    Any files in `from_tree` which are not in `to_tree` will be copied over to
+    `to_tree`.
+
+    Files existing in both `from_tree` and `to_tree` will be parsed.
+    Binary files on the same path in both directories will be merged using
+    :func:`delocate.tools.lipo_fuse`.
 
     Parameters
     ----------
@@ -102,30 +103,41 @@ def fuse_trees(
     from_tree : str or Path-like
         path of tree to fuse from (update from)
     lib_exts : sequence, optional
-        filename extensions for libraries
+        This parameter is deprecated and should be ignored.
+
+    .. versionchanged:: Unreleased
+        Binary files are auto-detected instead of using `lib_exts` to test file
+        suffixes.
     """
+    if lib_exts:
+        warnings.warn(
+            "`lib_exts` parameter will be removed in the future.",
+            FutureWarning,
+            stacklevel=2,
+        )
     for from_dirpath, dirnames, filenames in os.walk(Path(from_tree)):
-        to_dirpath = pjoin(to_tree, relpath(from_dirpath, from_tree))
+        to_dirpath = Path(to_tree, Path(from_dirpath).relative_to(from_tree))
         # Copy any missing directories in to_path
-        for dirname in tuple(dirnames):
-            to_path = pjoin(to_dirpath, dirname)
-            if not exists(to_path):
-                from_path = pjoin(from_dirpath, dirname)
+        for dirname in dirnames.copy():
+            to_path = Path(to_dirpath, dirname)
+            if not to_path.exists():
+                from_path = Path(from_dirpath, dirname)
                 shutil.copytree(from_path, to_path)
                 # If copying, don't further analyze this directory
                 dirnames.remove(dirname)
-        for fname in filenames:
-            root, ext = splitext(fname)
-            from_path = pjoin(from_dirpath, fname)
-            to_path = pjoin(to_dirpath, fname)
-            if not exists(to_path):
+        for filename in filenames:
+            file = Path(filename)
+            from_path = Path(from_dirpath, file)
+            to_path = Path(to_dirpath, file)
+            if not to_path.exists():
                 _copyfile(from_path, to_path)
-            elif cmp_contents(from_path, to_path):
-                pass
-            elif ext in lib_exts:
-                # existing lib that needs fuse
+                continue
+            if cmp_contents(from_path, to_path):
+                continue
+            try:
+                # Try to fuse this file with lipo
                 lipo_fuse(from_path, to_path, to_path)
-            else:
+            except RuntimeError:
                 # existing not-lib file not identical to source
                 _copyfile(from_path, to_path)
 

--- a/delocate/fuse.py
+++ b/delocate/fuse.py
@@ -111,7 +111,7 @@ def fuse_trees(
     """
     if lib_exts:
         warnings.warn(
-            "`lib_exts` parameter will be removed in the future.",
+            "`lib_exts` parameter ignored, will be removed in future.",
             FutureWarning,
             stacklevel=2,
         )

--- a/delocate/tests/test_scripts.py
+++ b/delocate/tests/test_scripts.py
@@ -397,7 +397,7 @@ def test_fix_wheel_archs(script_runner: ScriptRunner) -> None:
 
 
 @pytest.mark.xfail(  # type: ignore[misc]
-    sys.platform == "win32", reason="Can't run scripts."
+    sys.platform != "darwin", reason="requires lipo"
 )
 def test_fuse_wheels(script_runner: ScriptRunner) -> None:
     # Some tests for wheel fusing

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -1183,6 +1183,7 @@ def get_archs(libname: str) -> frozenset[str]:
     raise ValueError(f"Unexpected output: '{stdout}' for {libname}")
 
 
+@deprecated("Call lipo directly")
 def lipo_fuse(
     in_fname1: str | PathLike[str],
     in_fname2: str | PathLike[str],

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -1184,17 +1184,20 @@ def get_archs(libname: str) -> frozenset[str]:
 
 
 def lipo_fuse(
-    in_fname1: str, in_fname2: str, out_fname: str, ad_hoc_sign: bool = True
+    in_fname1: str | PathLike[str],
+    in_fname2: str | PathLike[str],
+    out_fname: str | PathLike[str],
+    ad_hoc_sign: bool = True,
 ) -> str:
     """Use lipo to merge libs `filename1`, `filename2`, store in `out_fname`.
 
     Parameters
     ----------
-    in_fname1 : str
+    in_fname1 : str or PathLike
         filename of library
-    in_fname2 : str
+    in_fname2 : str or PathLike
         filename of library
-    out_fname : str
+    out_fname : str or PathLike
         filename to which to write new fused library
     ad_hoc_sign : {True, False}, optional
         If True, sign file with ad-hoc signature


### PR DESCRIPTION
Updates merging to automatically detect binary files and removes the older behavior. This handles the common case of binary files having no suffix. Fixes #228

Using `_is_macho_file` has false negatives. Instead, all files are passed to the `lipo` command and its return code is used to determine if the file was valid to be merged. This might have its own issues, but I'd need to completely rewrite `lipo_fuse` to make it graceful.

The `lib_exts` parameter of `fuse_trees` is now ignored and I intend for it to be removed completely later.

This reuses old tests instead of trying to keep the old behavior. Updating the tests now could conflict with PR #234.

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/master/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/master/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests

