### PR TITLE
Suppress struct unpack error from macholib

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import stat
+import struct
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 from os.path import abspath, basename, dirname, exists, realpath, relpath
@@ -602,7 +603,9 @@ def _get_macos_min_version(
     """
     try:
         macho = MachO(dylib_path)
-    except ValueError as exc:
+    except struct.error:  # Parse error duing macholib's parsing
+        return  # Not a recognised Mach-O object file
+    except ValueError as exc:  # Raised by macholib for parse errors
         if str(exc.args[0]).startswith(
             ("Unknown fat header magic", "Unknown Mach-O header")
         ):

--- a/delocate/tests/test_delocating.py
+++ b/delocate/tests/test_delocating.py
@@ -781,6 +781,7 @@ def test_get_archs_and_version_from_wheel_name() -> None:
         (LIBA_STATIC, {}),
         # Non library
         (ICO_FILE, {}),
+        (Path(DATA_PATH, "empty"), {}),
     ],
 )
 def test_get_macos_min_version(


### PR DESCRIPTION
In some cases macholib will raise `struct.error` instead of `ValueError` such as when a file has less than 4 bytes to unpack. This issue was mentioned here: https://github.com/matthew-brett/delocate/issues/229#issuecomment-2621600344

Added a test for `_get_macos_min_version` with an empty file which triggers this error. This covers the suppressed struct.error branch.

This regression was caused by #235 which hasn't been released yet, so there's nothing to add to the changelog. I'm attempting to remove the reliance on the crudely implemented `_is_macho_file` function.

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests
