### PR TITLE
Support modifying wheels which already specify a Generator

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -789,9 +789,9 @@ def _check_and_update_wheel_name(
     return wheel_path
 
 
-def _get_delocate_generator_header() -> tuple[str, str]:
+def _get_delocate_generator_header() -> str:
     """Return Delocate's version info to be appended to the WHEEL metadata."""
-    return ("Generator", f"delocate {__version__}".rstrip())
+    return f"delocate {__version__}".rstrip()
 
 
 def _update_wheelfile(wheel_dir: Path, wheel_name: str) -> None:
@@ -818,8 +818,12 @@ def _update_wheelfile(wheel_dir: Path, wheel_name: str) -> None:
 
     # Mark wheel as modifed by this version of Delocate
     delocate_generator = _get_delocate_generator_header()
-    if delocate_generator not in info.items():
+    if "Generator" not in info:
         info.add_header(*delocate_generator)
+    else:
+        old_header = str(info.get("Generator"))
+        if old_header != delocate_generator:
+            info.replace_header("Generator", f"{old_header}, modified by {delocate_generator}")
 
     write_pkg_info(file_path, info)
 


### PR DESCRIPTION
Currently delocate adds a Generator metadata line whenever it runs on a wheel, so long as the Generator string doesn't exactly match what delocate would add.

This breaks the wheel metadata file when delocate is run on wheels which already specify a Generator - for example they are built with scikit.

Specifically it causes wheel_inspect.inspect_wheel to fail when loading a wheel which has multiple Generator lines in it's WHEEL metadata file.

A badly generated WHEEL file prior to this patch looked like this:
```
$ unzip mywheel.whl
$ cat mywheel/WHEEL
Wheel-Version: 1.0
Generator: scikit-build-core 0.10.7
Root-Is-Purelib: false
Tag: cp313-cp313-macosx_15_0_arm64
Generator: delocate 0.13.0
```

A WHEEL file created from the same process after this patch:

```
$ unzip mywheel.whl
$ cat mywheel/WHEEL
Wheel-Version: 1.0
Generator: scikit-build-core 0.10.7, modified by delocate 0.1.dev774+g44a151c
Root-Is-Purelib: false
Tag: cp313-cp313-macosx_15_0_arm6
```


### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [ ] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [ ] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [ ] Ensure new features are covered by tests
- [ ] Ensure fixes are verified by tests
