### PR TITLE
Only add otool '-m' flag conditionally

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ rules on making a good Changelog.
 
 - `get_archs` supports `PathLike` and raises `FileNotFoundError` instead of
   `RuntimeError` on missing files.
+- `-m` flag is only passed to `otool` if the file contains parenthesis. #247
 
 ### Removed
 

--- a/delocate/tests/test_install_names.py
+++ b/delocate/tests/test_install_names.py
@@ -232,7 +232,6 @@ class ToolArchMock(NamedTuple):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-L",
                     "example.so",
                 ): """\
@@ -245,7 +244,6 @@ example.so:
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-D",
                     "example.so",
                 ): """\
@@ -256,7 +254,6 @@ example.so:
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-l",
                     "example.so",
                 ): """\
@@ -278,7 +275,6 @@ cmdsize 0
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-L",
                     "example.so",
                 ): """\
@@ -295,7 +291,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-D",
                     "example.so",
                 ): """\
@@ -308,7 +303,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-l",
                     "example.so",
                 ): """\
@@ -334,7 +328,6 @@ cmdsize 0
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-L",
                     "example.so",
                 ): """\
@@ -351,7 +344,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-D",
                     "example.so",
                 ): """\
@@ -364,7 +356,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-l",
                     "example.so",
                 ): """\
@@ -390,7 +381,6 @@ cmdsize 0
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-L",
                     "example.so",
                 ): """\
@@ -407,7 +397,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-D",
                     "example.so",
                 ): """\
@@ -420,7 +409,6 @@ example.so (architecture arm64):
                     "otool",
                     "-arch",
                     "all",
-                    "-m",
                     "-l",
                     "example.so",
                 ): """\


### PR DESCRIPTION
Avoids unconditional usage of the `-m` flag which `llvm-otool` does not support.

Still leaves an edge case where `llvm-otool` is used AND the file contains a parenthesis. A function testing if the current `otool` supports `-m` would be more ideal but would be difficult for me to setup tests for.

Fixes #247

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests
