### PR TITLE
delocate/delocating.py: Sanitize each file only once, parallelize

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -38,12 +38,12 @@ from .pkginfo import read_pkg_info, write_pkg_info
 from .tmpdirs import TemporaryDirectory
 from .tools import (
     _remove_absolute_rpaths,
+    _update_signatures,
     dir2zip,
     find_package_dirs,
     get_archs,
     set_install_id,
     set_install_name,
-    validate_signature,
     zip2dir,
 )
 from .wheeltools import InWheel, rewrite_record
@@ -117,13 +117,17 @@ def delocate_tree_libs(
     lib_dict, copied_libraries = _copy_required_libs(
         lib_dict, lib_path, root_path, libraries_to_copy
     )
-    # Update the install names of local and copied libaries.
-    _update_install_names(
+    # Update the install names of local and copied libraries.
+    needs_codesign = _update_install_names(
         lib_dict, root_path, libraries_to_delocate | copied_libraries
     )
     # Remove absolute rpaths
     if sanitize_rpaths:
-        _sanitize_rpaths(lib_dict, libraries_to_delocate | copied_libraries)
+        needs_codesign |= _sanitize_rpaths(
+            lib_dict, libraries_to_delocate | copied_libraries
+        )
+
+    _update_signatures(needs_codesign, identity=None)
 
     return libraries_to_copy
 
@@ -131,12 +135,18 @@ def delocate_tree_libs(
 def _sanitize_rpaths(
     lib_dict: Mapping[str, Mapping[str, str]],
     files_to_delocate: Iterable[str],
-) -> None:
-    """Sanitize the rpaths of libraries."""
+) -> set[Path]:
+    """Sanitize the rpaths of libraries.
+
+    Returns the paths of modified binaries which require new code signing.
+    """
+    needs_signing = set()
     for required in files_to_delocate:
         # Set relative path for local library
         for requiring, orig_install_name in lib_dict[required].items():
-            _remove_absolute_rpaths(requiring)
+            if _remove_absolute_rpaths(requiring):
+                needs_signing.add(Path(requiring))
+    return needs_signing
 
 
 def _analyze_tree_libs(
@@ -227,8 +237,13 @@ def _update_install_names(
     lib_dict: Mapping[str, Mapping[str, str]],
     root_path: str,
     files_to_delocate: Iterable[str],
-) -> None:
-    """Update the install names of libraries."""
+) -> set[Path]:
+    """Update the install names of libraries.
+
+    Returns the paths of files which were modified and require a new signature.
+    """
+    needs_codesign = set()
+
     for required in files_to_delocate:
         # Set relative path for local library
         for requiring, orig_install_name in lib_dict[required].items():
@@ -248,7 +263,15 @@ def _update_install_names(
                     orig_install_name,
                     new_install_name,
                 )
-                set_install_name(requiring, orig_install_name, new_install_name)
+                set_install_name(
+                    requiring,
+                    orig_install_name,
+                    new_install_name,
+                    ad_hoc_sign=False,
+                )
+                needs_codesign.add(Path(requiring))
+
+    return needs_codesign
 
 
 def _dylibs_only(filename: str) -> bool:
@@ -405,11 +428,13 @@ def _decide_dylib_bundle_directory(
 
 
 def _make_install_name_ids_unique(
-    libraries: Iterable[str], install_id_prefix: str
+    libraries: Iterable[str | os.PathLike[str]], install_id_prefix: str
 ) -> None:
     """Replace each library's install name id with a unique id.
 
     This is to change install ids to be unique within Python space.
+
+    Libraries modifed by this function must be codesigned.
 
     Parameters
     ----------
@@ -436,8 +461,7 @@ def _make_install_name_ids_unique(
     if not install_id_prefix.endswith("/"):
         install_id_prefix += "/"
     for lib in libraries:
-        set_install_id(lib, install_id_prefix + basename(lib))
-        validate_signature(lib)
+        set_install_id(lib, install_id_prefix + Path(lib).name)
 
 
 def _get_macos_min_version(
@@ -937,12 +961,13 @@ def delocate_wheel(
                     f"\n{bads_report(bads, pjoin(tmpdir, 'wheel'))}"
                 )
         libraries_in_lib_path = [
-            pjoin(lib_path, basename(lib)) for lib in copied_libs
+            Path(lib_path, Path(lib).name) for lib in copied_libs
         ]
         _make_install_name_ids_unique(
             libraries=libraries_in_lib_path,
             install_id_prefix=DLC_PREFIX + relpath(lib_sdir, wheel_dir),
         )
+        _update_signatures(libraries_in_lib_path, identity=None)
         out_wheel_ = Path(out_wheel)
         out_wheel_fixed = _check_and_update_wheel_name(
             out_wheel_, Path(wheel_dir), require_target_macos_version

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -150,12 +150,8 @@ def _sanitize_rpaths(
     import concurrent.futures
 
     with concurrent.futures.ThreadPoolExecutor() as executer:
-        for requiring, needs in zip(
-            requiring_sanitizes,
-            executer.map(_remove_absolute_rpaths, requiring_sanitizes),
-        ):
-            if needs:
-                needs_signing.add(Path(requiring))
+        for modified_files in executer.map(_remove_absolute_rpaths, requiring_sanitizes):
+            needs_signing |= modified_files 
 
     return needs_signing
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -141,11 +141,16 @@ def _sanitize_rpaths(
     Returns the paths of modified binaries which require new code signing.
     """
     needs_signing = set()
+    requiring_sanitizes = {}  # requiring -> True
     for required in files_to_delocate:
         # Set relative path for local library
         for requiring, orig_install_name in lib_dict[required].items():
-            if _remove_absolute_rpaths(requiring):
-                needs_signing.add(Path(requiring))
+            requiring_sanitizes[requiring] = True
+
+    for requiring in requiring_sanitizes:
+        if _remove_absolute_rpaths(requiring):
+            needs_signing.add(Path(requiring))
+
     return needs_signing
 
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -150,8 +150,10 @@ def _sanitize_rpaths(
     import concurrent.futures
 
     with concurrent.futures.ThreadPoolExecutor() as executer:
-        for modified_files in executer.map(_remove_absolute_rpaths, requiring_sanitizes):
-            needs_signing |= modified_files 
+        for modified_files in executer.map(
+            _remove_absolute_rpaths, requiring_sanitizes
+        ):
+            needs_signing |= modified_files
 
     return needs_signing
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -140,7 +140,7 @@ def _sanitize_rpaths(
 
     Returns the paths of modified binaries which require new code signing.
     """
-    needs_signing = set()
+    needs_signing: set[Path] = set()
     requiring_sanitizes = {}  # requiring -> True
     for required in files_to_delocate:
         # Set relative path for local library

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -797,7 +797,7 @@ def _remove_absolute_rpaths(filename: str | PathLike[str]) -> set[Path]:
     filename : str or Path
         filename of library
     """
-    needs_signing = set()
+    needs_signing: set[Path] = set()
     while True:
         rpaths_to_remove = _find_absolute_rpaths_to_remove(filename)
         if not rpaths_to_remove:

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -787,22 +787,22 @@ def _find_absolute_rpaths_to_remove(
 
 
 @ensure_writable
-def _remove_absolute_rpaths(filename: str | PathLike[str]) -> bool:
+def _remove_absolute_rpaths(filename: str | PathLike[str]) -> set[Path]:
     """Remove absolute filename rpaths in `filename`.
 
-    Returns True if file was modifed, modifed files need to be code signed.
+    Returns the paths of modified binaries which require new code signing.
 
     Parameters
     ----------
     filename : str or Path
         filename of library
     """
-    was_modified = False
+    needs_signing = set()
     while True:
         rpaths_to_remove = _find_absolute_rpaths_to_remove(filename)
         if not rpaths_to_remove:
-            return was_modified
-        was_modified = True
+            return needs_signing
+        needs_signing.add(Path(filename))
         options: list[str] = []
         # Can run many delete_rpath's as one command to install_name_tool if
         # there are no duplicates.


### PR DESCRIPTION
Performance improvement based in part on a change in #256. PR is on top of #260, for fixing the handling of duplicate rpaths.

- `_sanitize_rpaths` now calls `_remove_absolute_rpaths` only once for the same file. This saves calls to `otool` to retrieve rpaths.
- Parallelize the calls of `_remove_absolute_rpaths` using `concurrent.futures.ThreadPoolExecutor`.

### Pull Request Checklist

- [ ] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [ ] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [ ] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [ ] Ensure new features are covered by tests
- [ ] Ensure fixes are verified by tests
