### PR TITLE
delocate/delocating.py (_update_install_names): Parallelize

### DIFF
--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -38,12 +38,12 @@ from .pkginfo import read_pkg_info, write_pkg_info
 from .tmpdirs import TemporaryDirectory
 from .tools import (
     _remove_absolute_rpaths,
+    _update_signatures,
     dir2zip,
     find_package_dirs,
     get_archs,
     set_install_id,
     set_install_name,
-    validate_signature,
     zip2dir,
 )
 from .wheeltools import InWheel, rewrite_record
@@ -117,13 +117,17 @@ def delocate_tree_libs(
     lib_dict, copied_libraries = _copy_required_libs(
         lib_dict, lib_path, root_path, libraries_to_copy
     )
-    # Update the install names of local and copied libaries.
-    _update_install_names(
+    # Update the install names of local and copied libraries.
+    needs_codesign = _update_install_names(
         lib_dict, root_path, libraries_to_delocate | copied_libraries
     )
     # Remove absolute rpaths
     if sanitize_rpaths:
-        _sanitize_rpaths(lib_dict, libraries_to_delocate | copied_libraries)
+        needs_codesign |= _sanitize_rpaths(
+            lib_dict, libraries_to_delocate | copied_libraries
+        )
+
+    _update_signatures(needs_codesign, identity=None)
 
     return libraries_to_copy
 
@@ -131,12 +135,18 @@ def delocate_tree_libs(
 def _sanitize_rpaths(
     lib_dict: Mapping[str, Mapping[str, str]],
     files_to_delocate: Iterable[str],
-) -> None:
-    """Sanitize the rpaths of libraries."""
+) -> set[Path]:
+    """Sanitize the rpaths of libraries.
+
+    Returns the paths of modified binaries which require new code signing.
+    """
+    needs_signing = set()
     for required in files_to_delocate:
         # Set relative path for local library
         for requiring, orig_install_name in lib_dict[required].items():
-            _remove_absolute_rpaths(requiring)
+            if _remove_absolute_rpaths(requiring):
+                needs_signing.add(Path(requiring))
+    return needs_signing
 
 
 def _analyze_tree_libs(
@@ -227,8 +237,13 @@ def _update_install_names(
     lib_dict: Mapping[str, Mapping[str, str]],
     root_path: str,
     files_to_delocate: Iterable[str],
-) -> None:
-    """Update the install names of libraries."""
+) -> set[Path]:
+    """Update the install names of libraries.
+
+    Returns the paths of files which were modified and require a new signature.
+    """
+    needs_codesign = set()
+
     for required in files_to_delocate:
         # Set relative path for local library
         for requiring, orig_install_name in lib_dict[required].items():
@@ -248,7 +263,15 @@ def _update_install_names(
                     orig_install_name,
                     new_install_name,
                 )
-                set_install_name(requiring, orig_install_name, new_install_name)
+                set_install_name(
+                    requiring,
+                    orig_install_name,
+                    new_install_name,
+                    ad_hoc_sign=False,
+                )
+                needs_codesign.add(Path(requiring))
+
+    return needs_codesign
 
 
 def _dylibs_only(filename: str) -> bool:
@@ -405,11 +428,13 @@ def _decide_dylib_bundle_directory(
 
 
 def _make_install_name_ids_unique(
-    libraries: Iterable[str], install_id_prefix: str
+    libraries: Iterable[str | os.PathLike[str]], install_id_prefix: str
 ) -> None:
     """Replace each library's install name id with a unique id.
 
     This is to change install ids to be unique within Python space.
+
+    Libraries modifed by this function must be codesigned.
 
     Parameters
     ----------
@@ -436,8 +461,7 @@ def _make_install_name_ids_unique(
     if not install_id_prefix.endswith("/"):
         install_id_prefix += "/"
     for lib in libraries:
-        set_install_id(lib, install_id_prefix + basename(lib))
-        validate_signature(lib)
+        set_install_id(lib, install_id_prefix + Path(lib).name)
 
 
 def _get_macos_min_version(
@@ -937,12 +961,13 @@ def delocate_wheel(
                     f"\n{bads_report(bads, pjoin(tmpdir, 'wheel'))}"
                 )
         libraries_in_lib_path = [
-            pjoin(lib_path, basename(lib)) for lib in copied_libs
+            Path(lib_path, Path(lib).name) for lib in copied_libs
         ]
         _make_install_name_ids_unique(
             libraries=libraries_in_lib_path,
             install_id_prefix=DLC_PREFIX + relpath(lib_sdir, wheel_dir),
         )
+        _update_signatures(libraries_in_lib_path, identity=None)
         out_wheel_ = Path(out_wheel)
         out_wheel_fixed = _check_and_update_wheel_name(
             out_wheel_, Path(wheel_dir), require_target_macos_version

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -277,7 +277,9 @@ def _update_install_names(
     with concurrent.futures.ThreadPoolExecutor() as executer:
         futures = []
         for requiring, updates in requiring_updates.items():
-            futures.append(executer.submit(_set_install_names, requiring, updates))
+            futures.append(
+                executer.submit(_set_install_names, requiring, updates)
+            )
         for future in futures:
             future.result()
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import functools
 import logging
 import os
@@ -273,7 +274,8 @@ def _update_install_names(
                 )
                 needs_codesign.add(Path(requiring))
 
-    def update(requiring, updates):
+    def update(item):
+        requiring, updates = item
         for orig_install_name, new_install_name in updates:
             set_install_name(
                 requiring,
@@ -282,8 +284,9 @@ def _update_install_names(
                 ad_hoc_sign=False,
             )
 
-    for requiring, updates in requiring_updates.items():
-        update(requiring, updates)
+    with concurrent.futures.ThreadPoolExecutor() as executer:
+        for _ in executer.map(update, requiring_updates.items()):
+            pass
 
     return needs_codesign
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -274,13 +274,12 @@ def _update_install_names(
                 )
                 needs_codesign.add(Path(requiring))
 
-    def update(item):
-        requiring, updates = item
-        _set_install_names(requiring, updates)
-
     with concurrent.futures.ThreadPoolExecutor() as executer:
-        for _ in executer.map(update, requiring_updates.items()):
-            pass
+        futures = []
+        for requiring, updates in requiring_updates.items():
+            futures.append(executer.submit(_set_install_names, requiring, updates))
+        for future in futures:
+            future.result()
 
     return needs_codesign
 

--- a/delocate/delocating.py
+++ b/delocate/delocating.py
@@ -40,12 +40,12 @@ from .pkginfo import read_pkg_info, write_pkg_info
 from .tmpdirs import TemporaryDirectory
 from .tools import (
     _remove_absolute_rpaths,
+    _set_install_names,
     _update_signatures,
     dir2zip,
     find_package_dirs,
     get_archs,
     set_install_id,
-    set_install_name,
     zip2dir,
 )
 from .wheeltools import InWheel, rewrite_record
@@ -276,13 +276,7 @@ def _update_install_names(
 
     def update(item):
         requiring, updates = item
-        for orig_install_name, new_install_name in updates:
-            set_install_name(
-                requiring,
-                orig_install_name,
-                new_install_name,
-                ad_hoc_sign=False,
-            )
+        _set_install_names(requiring, updates)
 
     with concurrent.futures.ThreadPoolExecutor() as executer:
         for _ in executer.map(update, requiring_updates.items()):

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -537,7 +537,7 @@ def _set_install_names(
     options: list[str] = []
     for oldname, newname in changes:
         options.extend(("-change", oldname, newname))
-    _run(["install_name_tool", *options, str(Path(path))], check=True)
+    _run(["install_name_tool", *options, path], check=True)
 
 
 @ensure_writable

--- a/delocate/tools.py
+++ b/delocate/tools.py
@@ -523,7 +523,7 @@ def _get_install_ids(filename: str | PathLike[str]) -> dict[str, str]:
 
 @ensure_writable
 def _set_install_names(
-    path: str | PathLike[str], changes: Iterable[Sequence[str, str]]
+    path: str | PathLike[str], changes: Iterable[tuple[str, str]]
 ) -> None:
     """Set install names in binary `path`.
 
@@ -532,7 +532,7 @@ def _set_install_names(
     path
         Path to binary file.
     changes
-        Sequence of (old, new)
+        (old, new) pairs
     """
     options: list[str] = []
     for oldname, newname in changes:


### PR DESCRIPTION
Based on a change in #256. PR is on top of #260.
- Update all install names in a file using one invocation of `install_name_tool`
- Do not check current installation names using `otool` before each update
- Parallelize the `install_name_tool` invocations using `concurrent.futures.ThreadPoolExecutor`

### Pull Request Checklist

- [ ] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [ ] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [ ] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [ ] Ensure new features are covered by tests
- [ ] Ensure fixes are verified by tests
