### PR TITLE
Update deprecated license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2025, Matthew Brett and the Delocate contributors.
+Copyright (c) 2014-2026, Matthew Brett and the Delocate contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -13,13 +13,13 @@ maintainers = [
 ]
 readme = "README.rst"
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+license = "BSD-2-Clause"
+license-files = ["LICENSE"]
 dependencies = ["packaging>=20.9", "typing_extensions>=4.12.2", "macholib"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Previous license classifiers were causing deprecation warnings

Now following current guidelines:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files

Setuptools bumped to support those guidelines

Also updated the copyright year to 2026

### Pull Request Checklist

- [x] Read and follow the [CONTRIBUTING.md](https://github.com/matthew-brett/delocate/blob/main/CONTRIBUTING.md) guide
- [x] Mentioned relevant [issues](https://github.com/matthew-brett/delocate/issues)
- [x] Append public facing changes to [Changelog.md](https://github.com/matthew-brett/delocate/blob/main/Changelog.md)
- [x] Ensure new features are covered by tests
- [x] Ensure fixes are verified by tests
